### PR TITLE
notify telegram webhook

### DIFF
--- a/packages/nextjs/.env.example
+++ b/packages/nextjs/.env.example
@@ -13,3 +13,11 @@ NEXT_PUBLIC_ALCHEMY_API_KEY=
 NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=
 # will be used in production
 NEXT_PUBLIC_PONDER_URL=
+
+
+POSTGRES_URL="postgresql://postgres:mysecretpassword@localhost:5432/postgres"
+NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_SECRET=somereallysecretsecret
+
+TELEGRAM_BOT_URL=http://localhost:8080
+TELEGRAM_WEBHOOK_SECRET=your_secret_here

--- a/packages/nextjs/app/api/grants/new/route.ts
+++ b/packages/nextjs/app/api/grants/new/route.ts
@@ -4,6 +4,7 @@ import { parseEther } from "viem";
 import { applyFormSchema } from "~~/app/apply/schema";
 import { GrantInsert, createGrant } from "~~/services/database/repositories/grants";
 import { createStage } from "~~/services/database/repositories/stages";
+import { notifyTelegramBot } from "~~/services/notifications/telegram";
 import { authOptions } from "~~/utils/auth";
 
 export type CreateNewGrantReqBody = Omit<GrantInsert, "requestedFunds" | "builderAddress"> & {
@@ -34,6 +35,12 @@ export async function POST(req: Request) {
 
     const [createdStage] = await createStage({
       grantId: createdGrant.id,
+    });
+
+    await notifyTelegramBot("grant", {
+      id: createdGrant.id,
+      ...body,
+      builderAddress,
     });
 
     return NextResponse.json({ grantId: createdGrant.id, stageId: createdStage.id }, { status: 201 });

--- a/packages/nextjs/app/api/stages/new/route.ts
+++ b/packages/nextjs/app/api/stages/new/route.ts
@@ -6,6 +6,7 @@ import deployedContracts from "~~/contracts/deployedContracts";
 import scaffoldConfig from "~~/scaffold.config";
 import { getGrantById } from "~~/services/database/repositories/grants";
 import { StageInsert, createStage, updateStageStatusToCompleted } from "~~/services/database/repositories/stages";
+import { notifyTelegramBot } from "~~/services/notifications/telegram";
 import { authOptions } from "~~/utils/auth";
 import { EIP_712_DOMAIN, EIP_712_TYPES__APPLY_FOR_STAGE } from "~~/utils/eip712";
 import { getAlchemyHttpUrl } from "~~/utils/scaffold-eth";
@@ -91,6 +92,11 @@ export async function POST(req: Request) {
       grantId: newStage.grantId,
       milestone: newStage.milestone,
       stageNumber: latestStage.stageNumber + 1,
+    });
+
+    await notifyTelegramBot("stage", {
+      newStage: body,
+      grant: grant,
     });
 
     return NextResponse.json({ grantId: newStage.grantId, stageId: createdStage.id }, { status: 201 });

--- a/packages/nextjs/services/notifications/telegram.ts
+++ b/packages/nextjs/services/notifications/telegram.ts
@@ -1,7 +1,21 @@
+import { CreateNewGrantReqBody } from "~~/app/api/grants/new/route";
+import { CreateNewStageReqBody } from "~~/app/api/stages/new/route";
+import { GrantWithStages } from "~~/app/grants/[grantId]/page";
+
 const TELEGRAM_BOT_URL = process.env.TELEGRAM_BOT_URL;
 const TELEGRAM_WEBHOOK_SECRET = process.env.TELEGRAM_WEBHOOK_SECRET;
 
-export async function notifyTelegramBot(endpoint: "grant" | "stage", data: unknown) {
+type StageData = {
+  newStage: CreateNewStageReqBody;
+  grant: GrantWithStages;
+};
+
+type GrantData = CreateNewGrantReqBody & { builderAddress: string };
+
+export async function notifyTelegramBot<T extends "grant" | "stage">(
+  endpoint: T,
+  data: T extends "grant" ? GrantData : StageData,
+) {
   if (!TELEGRAM_BOT_URL || !TELEGRAM_WEBHOOK_SECRET) {
     if (!TELEGRAM_BOT_URL) {
       console.warn("TELEGRAM_BOT_URL is not set. Telegram notifications will be disabled.");

--- a/packages/nextjs/services/notifications/telegram.ts
+++ b/packages/nextjs/services/notifications/telegram.ts
@@ -1,0 +1,35 @@
+const TELEGRAM_BOT_URL = process.env.TELEGRAM_BOT_URL;
+const TELEGRAM_WEBHOOK_SECRET = process.env.TELEGRAM_WEBHOOK_SECRET;
+
+export async function notifyTelegramBot(endpoint: "grant" | "stage", data: unknown) {
+  if (!TELEGRAM_BOT_URL || !TELEGRAM_WEBHOOK_SECRET) {
+    if (!TELEGRAM_BOT_URL) {
+      console.warn("TELEGRAM_BOT_URL is not set. Telegram notifications will be disabled.");
+    }
+
+    if (!TELEGRAM_WEBHOOK_SECRET) {
+      console.warn("TELEGRAM_WEBHOOK_SECRET is not set. Telegram notifications will be disabled.");
+    }
+    return;
+  }
+
+  try {
+    const response = await fetch(`${TELEGRAM_BOT_URL}/webhook/${endpoint}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Webhook-Secret": TELEGRAM_WEBHOOK_SECRET,
+      },
+      body: JSON.stringify(data),
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    return response.json();
+  } catch (error) {
+    // We don't throw here to prevent the main flow from failing if notifications fail
+    console.error(`Error notifying Telegram bot (${endpoint}):`, error);
+  }
+}


### PR DESCRIPTION
## Description: 

Went with simpler approach. Exposed an endpoint from bot side which when hit by some server with valid secret (`WEBHOOK_SECRET`) will send notification to configured group.  

Another approach would be using PostgreSQL's `LISTEN/NOTIFY` where we use ENS-PG postgres DB directly in TG bot and setup `LISTEN/NOTIFY` triggers wherever an insert in grant and stage table happens. 


## To test: 

### In this repo: 

1. Switch to this branch. 

2. Add the following variables in `.env.local`: 

```
POSTGRES_URL="postgresql://postgres:mysecretpassword@localhost:5432/postgres"
NEXTAUTH_URL=http://localhost:3000
NEXTAUTH_SECRET=somereallysecretsecret

TELEGRAM_BOT_URL=http://localhost:8080
TELEGRAM_WEBHOOK_SECRET=your_secret_here
```

3. Setup the dev environment: 

    <details>
    
    <summary>
        Update `Stream.sol` to lower frequency
    </summary>
    
    ```solidity
    // SPDX-License-Identifier: MIT
    pragma solidity >=0.8.0 <0.9.0;
    
    import "@openzeppelin/contracts/access/AccessControl.sol";
    
    contract Stream is AccessControl {
	    bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
    
	    struct GrantStream {
		    uint256 cap;
		    uint256 last;
		    uint256 amountLeft;
		    uint8 grantNumber;
		    uint8 stageNumber;
		    address builder;
	    }
    
	    struct BuilderGrantData {
		    uint256 grantId;
		    uint8 grantNumber;
	    }
    
	    mapping(uint256 => GrantStream) public grantStreams;
	    uint256 public nextGrantId = 1;
    
	    mapping(address => BuilderGrantData[]) public builderGrants;
    
	    uint256 public constant FULL_STREAM_UNLOCK_PERIOD = 60; // 1 min
	    uint256 public constant DUST_THRESHOLD = 1000000000000000; // 0.001 ETH
    
	    event Withdraw(
		    address indexed to,
		    uint256 amount,
		    string reason,
		    uint256 grantId,
		    uint8 grantNumber,
		    uint8 stageNumber
	    );
	    event AddGrant(uint256 indexed grantId, address indexed to, uint256 amount);
	    event ReinitializeGrant(
		    uint256 indexed grantId,
		    address indexed to,
		    uint256 amount
	    );
	    event MoveGrantToNextStage(
		    uint256 indexed grantId,
		    address indexed to,
		    uint256 amount,
		    uint8 grantNumber,
		    uint8 stageNumber
	    );
	    event ReinitializeNextStage(
		    uint256 indexed grantId,
		    address indexed builder,
		    uint256 amount,
		    uint8 grantNumber,
		    uint8 stageNumber
	    );
	    event UpdateGrant(
		    uint256 indexed grantId,
		    address indexed to,
		    uint256 cap,
		    uint256 last,
		    uint256 amountLeft,
		    uint8 grantNumber,
		    uint8 stageNumber
	    );
	    event AddOwner(address indexed newOwner, address indexed addedBy);
	    event RemoveOwner(address indexed removedOwner, address indexed removedBy);
    
	    // Custom errors
	    error NoActiveStream();
	    error InsufficientContractFunds();
	    error UnauthorizedWithdrawal();
	    error InsufficientStreamFunds();
	    error FailedToSendEther();
	    error PreviousAmountNotFullyWithdrawn();
	    error AlreadyWithdrawnFromGrant();
    
	    constructor(address[] memory _initialOwners) {
		    _setRoleAdmin(OWNER_ROLE, OWNER_ROLE);
		    for (uint i = 0; i < _initialOwners.length; i++) {
			    _grantRole(OWNER_ROLE, _initialOwners[i]);
		    }
	    }
    
	    function unlockedGrantAmount(
		    uint256 _grantId
	    ) public view returns (uint256) {
		    GrantStream memory grantStream = grantStreams[_grantId];
		    if (grantStream.cap == 0) revert NoActiveStream();
    
		    if (grantStream.amountLeft == 0) {
			    return 0;
		    }
    
		    uint256 elapsedTime = block.timestamp - grantStream.last;
		    uint256 unlockedAmount = (grantStream.cap * elapsedTime) /
			    FULL_STREAM_UNLOCK_PERIOD;
    
		    return
			    unlockedAmount > grantStream.amountLeft
				    ? grantStream.amountLeft
				    : unlockedAmount;
	    }
    
	    function addGrantStream(
		    address _builder,
		    uint256 _cap,
		    uint8 _grantNumber
	    ) public onlyRole(OWNER_ROLE) returns (uint256) {
		    // check if grantStream with same grantNumber already exists
		    uint256 existingGrantId;
		    BuilderGrantData[] memory existingBuilderGrants = builderGrants[
			    _builder
		    ];
		    for (uint i = 0; i < existingBuilderGrants.length; i++) {
			    GrantStream memory existingGrant = grantStreams[
				    existingBuilderGrants[i].grantId
			    ];
			    if (existingGrant.grantNumber == _grantNumber) {
				    if (existingGrant.cap != existingGrant.amountLeft) {
					    revert AlreadyWithdrawnFromGrant();
				    }
				    existingGrantId = existingBuilderGrants[i].grantId;
				    break;
			    }
		    }
    
		    // update existing grant or create new one
		    uint256 grantId = existingGrantId != 0
			    ? existingGrantId
			    : nextGrantId++;
    
		    grantStreams[grantId] = GrantStream({
			    cap: _cap,
			    last: block.timestamp,
			    amountLeft: _cap,
			    grantNumber: _grantNumber,
			    stageNumber: 1,
			    builder: _builder
		    });
    
		    if (existingGrantId == 0) {
			    builderGrants[_builder].push(
				    BuilderGrantData({
					    grantId: grantId,
					    grantNumber: _grantNumber
				    })
			    );
			    emit AddGrant(grantId, _builder, _cap);
		    } else {
			    emit ReinitializeGrant(grantId, _builder, _cap);
		    }
		    return grantId;
	    }
    
	    function moveGrantToNextStage(
		    uint256 _grantId,
		    uint256 _cap
	    ) public onlyRole(OWNER_ROLE) {
		    GrantStream storage grantStream = grantStreams[_grantId];
		    if (grantStream.cap == 0) revert NoActiveStream();
    
		    // If amountLeft equals cap, reinitialize with same stage number
		    if (grantStream.amountLeft == grantStream.cap) {
			    grantStream.cap = _cap;
			    grantStream.last = block.timestamp;
			    grantStream.amountLeft = _cap;
			    // Stage number remains the same
			    emit ReinitializeNextStage(
				    _grantId,
				    grantStream.builder,
				    _cap,
				    grantStream.grantNumber,
				    grantStream.stageNumber
			    );
		    } else {
			    if (grantStream.amountLeft > DUST_THRESHOLD)
				    revert PreviousAmountNotFullyWithdrawn();
    
			    if (grantStream.amountLeft > 0) {
				    (bool sent, ) = payable(grantStream.builder).call{
					    value: grantStream.amountLeft
				    }("");
				    if (!sent) revert FailedToSendEther();
			    }
    
			    grantStream.cap = _cap;
			    grantStream.last = block.timestamp;
			    grantStream.amountLeft = _cap;
			    grantStream.stageNumber += 1;
    
			    emit MoveGrantToNextStage(
				    _grantId,
				    grantStream.builder,
				    _cap,
				    grantStream.grantNumber,
				    grantStream.stageNumber
			    );
		    }
	    }
    
	    function updateGrant(
		    uint256 _grantId,
		    uint256 _cap,
		    uint256 _last,
		    uint256 _amountLeft,
		    uint8 _stageNumber
	    ) public onlyRole(OWNER_ROLE) {
		    GrantStream storage grantStream = grantStreams[_grantId];
		    if (grantStream.cap == 0) revert NoActiveStream();
		    grantStream.cap = _cap;
		    grantStream.last = _last;
		    grantStream.amountLeft = _amountLeft;
		    grantStream.stageNumber = _stageNumber;
    
		    emit UpdateGrant(
			    _grantId,
			    grantStream.builder,
			    _cap,
			    grantStream.last,
			    grantStream.amountLeft,
			    grantStream.grantNumber,
			    grantStream.stageNumber
		    );
	    }
    
	    function streamWithdraw(
		    uint256 _grantId,
		    uint256 _amount,
		    string memory _reason
	    ) public {
		    if (address(this).balance < _amount) revert InsufficientContractFunds();
		    GrantStream storage grantStream = grantStreams[_grantId];
		    if (grantStream.cap == 0) revert NoActiveStream();
		    if (msg.sender != grantStream.builder) revert UnauthorizedWithdrawal();
    
		    uint256 totalAmountCanWithdraw = unlockedGrantAmount(_grantId);
		    if (totalAmountCanWithdraw < _amount) revert InsufficientStreamFunds();
    
		    uint256 elapsedTime = block.timestamp - grantStream.last;
		    uint256 timeToDeduct = (elapsedTime * _amount) / totalAmountCanWithdraw;
    
		    grantStream.last = grantStream.last + timeToDeduct;
		    grantStream.amountLeft -= _amount;
    
		    (bool sent, ) = msg.sender.call{ value: _amount }("");
		    if (!sent) revert FailedToSendEther();
    
		    emit Withdraw(
			    msg.sender,
			    _amount,
			    _reason,
			    _grantId,
			    grantStream.grantNumber,
			    grantStream.stageNumber
		    );
	    }
    
	    function getBuilderGrantCount(
		    address _builder
	    ) public view returns (uint256) {
		    return builderGrants[_builder].length;
	    }
    
	    function addOwner(address newOwner) public onlyRole(OWNER_ROLE) {
		    grantRole(OWNER_ROLE, newOwner);
		    emit AddOwner(newOwner, msg.sender);
	    }
    
	    function removeOwner(address owner) public onlyRole(OWNER_ROLE) {
		    revokeRole(OWNER_ROLE, owner);
		    emit RemoveOwner(owner, msg.sender);
	    }
    
	    function getGrantIdByBuilderAndGrantNumber(
		    address _builder,
		    uint8 _grantNumber
	    ) public view returns (uint256) {
		    for (uint256 i = 0; i < builderGrants[_builder].length; i++) {
			    if (builderGrants[_builder][i].grantNumber == _grantNumber) {
				    return builderGrants[_builder][i].grantId;
			    }
		    }
		    return 0;
	    }
    
	    receive() external payable {}
    
	    fallback() external payable {}
    }
    
    ```
    
    </details>

- Update `export const MINIMAL_VOTES_FOR_FINAL_APPROVAL = 1;`

4. scaffold.config.ts => `chains.hardhat`


### bot repo: 

Follow the README instructions in https://github.com/technophile-04/ens-pg-bot


### Testing: 

1. Create a grant and it should be notified in the group
2. New stage proposal will be also notified. 
