### PR TITLE
Limit data exposure in public grant views

### DIFF
--- a/packages/nextjs/app/_components/Grants/ApprovedGrantsList.tsx
+++ b/packages/nextjs/app/_components/Grants/ApprovedGrantsList.tsx
@@ -2,13 +2,13 @@
 
 import { useState } from "react";
 import { GrantItem } from "./GrantItem";
-import { GrantWithStages } from "~~/app/grants/[grantId]/page";
 import { Pagination } from "~~/components/pg-ens/Pagination";
+import { PublicGrant } from "~~/services/database/repositories/grants";
 
 const GRANTS_PER_PAGE = 8;
 
 type ApprovedGrantsListProps = {
-  approvedGrants: NonNullable<GrantWithStages>[];
+  approvedGrants: PublicGrant[];
 };
 
 export const ApprovedGrantsList = ({ approvedGrants }: ApprovedGrantsListProps) => {

--- a/packages/nextjs/app/_components/Grants/GrantItem.tsx
+++ b/packages/nextjs/app/_components/Grants/GrantItem.tsx
@@ -3,19 +3,19 @@ import Link from "next/link";
 import { GrantMilestonesModal } from "./GrantMilestonesModal";
 import { formatEther } from "viem";
 import { MagnifyingGlassIcon } from "@heroicons/react/24/outline";
-import { GrantWithStages } from "~~/app/grants/[grantId]/page";
 import { Badge } from "~~/components/pg-ens/Badge";
 import { Button } from "~~/components/pg-ens/Button";
 import { GrantProgressBar } from "~~/components/pg-ens/GrantProgressBar";
 import { Address } from "~~/components/scaffold-eth";
 import { useAuthSession } from "~~/hooks/pg-ens/useAuthSession";
 import { useWithdrawals } from "~~/hooks/pg-ens/useWithdrawals";
+import { PublicGrant } from "~~/services/database/repositories/grants";
 import { Stage } from "~~/services/database/repositories/stages";
 import { getFormattedDate } from "~~/utils/getFormattedDate";
 import { multilineStringToTsx } from "~~/utils/multiline-string-to-tsx";
 
 type GrantItemProps = {
-  grant: NonNullable<GrantWithStages>;
+  grant: PublicGrant;
   latestsShownStatus: "all" | "approved";
 };
 

--- a/packages/nextjs/app/_components/Grants/index.tsx
+++ b/packages/nextjs/app/_components/Grants/index.tsx
@@ -1,12 +1,14 @@
 import { ApprovedGrantsList } from "./ApprovedGrantsList";
-import { GrantWithStages } from "~~/app/grants/[grantId]/page";
-import { getAllGrants } from "~~/services/database/repositories/grants";
+import { getPublicGrants } from "~~/services/database/repositories/grants";
 
 export const ApprovedGrants = async () => {
-  const allGrants = await getAllGrants();
-  const approvedGrants = allGrants.filter(grant =>
-    grant.stages.some(stage => stage.status === "approved" || stage.status === "completed"),
-  ) as NonNullable<GrantWithStages>[];
+  const allGrants = await getPublicGrants();
+  const approvedGrants = allGrants
+    .filter(grant => grant.stages.some(stage => stage.status === "approved" || stage.status === "completed"))
+    .map(grant => ({
+      ...grant,
+      builderAddress: grant.builderAddress as `0x${string}`,
+    }));
 
   if (approvedGrants.length === 0) return null;
 

--- a/packages/nextjs/app/_components/Grants/index.tsx
+++ b/packages/nextjs/app/_components/Grants/index.tsx
@@ -3,12 +3,9 @@ import { getPublicGrants } from "~~/services/database/repositories/grants";
 
 export const ApprovedGrants = async () => {
   const allGrants = await getPublicGrants();
-  const approvedGrants = allGrants
-    .filter(grant => grant.stages.some(stage => stage.status === "approved" || stage.status === "completed"))
-    .map(grant => ({
-      ...grant,
-      builderAddress: grant.builderAddress as `0x${string}`,
-    }));
+  const approvedGrants = allGrants.filter(grant =>
+    grant.stages.some(stage => stage.status === "approved" || stage.status === "completed"),
+  );
 
   if (approvedGrants.length === 0) return null;
 

--- a/packages/nextjs/services/database/repositories/grants.ts
+++ b/packages/nextjs/services/database/repositories/grants.ts
@@ -28,7 +28,6 @@ export async function getPublicGrants() {
       title: true,
       description: true,
       builderAddress: true,
-      requestedFunds: true,
     },
     with: {
       stages: {

--- a/packages/nextjs/services/database/repositories/grants.ts
+++ b/packages/nextjs/services/database/repositories/grants.ts
@@ -4,6 +4,7 @@ import { grants, stages } from "~~/services/database/config/schema";
 
 export type GrantInsert = InferInsertModel<typeof grants>;
 export type Grant = InferSelectModel<typeof grants>;
+export type PublicGrant = Awaited<ReturnType<typeof getPublicGrants>>[number];
 
 export async function getAllGrants() {
   return await db.query.grants.findMany({
@@ -12,6 +13,33 @@ export async function getAllGrants() {
       stages: {
         // this makes sure latest stage is first
         orderBy: [desc(stages.stageNumber)],
+      },
+    },
+  });
+}
+
+// Excludes sensitive information for public pages
+export async function getPublicGrants() {
+  return await db.query.grants.findMany({
+    orderBy: [desc(grants.submitedAt)],
+    columns: {
+      id: true,
+      grantNumber: true,
+      title: true,
+      description: true,
+      builderAddress: true,
+      requestedFunds: true,
+    },
+    with: {
+      stages: {
+        orderBy: [desc(stages.stageNumber)],
+        columns: {
+          id: true,
+          stageNumber: true,
+          submitedAt: true,
+          grantAmount: true,
+          status: true,
+        },
       },
     },
   });


### PR DESCRIPTION
Creating a new `getPublicGrants` function that doesn't get all grants data, so it doesn't get exposed in public views when users check their console.

GrantDetails page will keep all data from grants since it's displayed in the screen (only admins and the own grantee can access to that page)

## To test: 

### In this repo: 

1. Switch to this branch. 

2. Add the following variables in `.env.local`: 

```
POSTGRES_URL="postgresql://postgres:mysecretpassword@localhost:5432/postgres"
NEXTAUTH_URL=http://localhost:3000
NEXTAUTH_SECRET=somereallysecretsecret
```

3. Setup the dev environment: 

    <details>
    
    <summary>
        Update `Stream.sol` to lower frequency
    </summary>
    
    ```solidity
    // SPDX-License-Identifier: MIT
    pragma solidity >=0.8.0 <0.9.0;
    
    import "@openzeppelin/contracts/access/AccessControl.sol";
    
    contract Stream is AccessControl {
	    bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
    
	    struct GrantStream {
		    uint256 cap;
		    uint256 last;
		    uint256 amountLeft;
		    uint8 grantNumber;
		    uint8 stageNumber;
		    address builder;
	    }
    
	    struct BuilderGrantData {
		    uint256 grantId;
		    uint8 grantNumber;
	    }
    
	    mapping(uint256 => GrantStream) public grantStreams;
	    uint256 public nextGrantId = 1;
    
	    mapping(address => BuilderGrantData[]) public builderGrants;
    
	    uint256 public constant FULL_STREAM_UNLOCK_PERIOD = 60; // 1 min
	    uint256 public constant DUST_THRESHOLD = 1000000000000000; // 0.001 ETH
    
	    event Withdraw(
		    address indexed to,
		    uint256 amount,
		    string reason,
		    uint256 grantId,
		    uint8 grantNumber,
		    uint8 stageNumber
	    );
	    event AddGrant(uint256 indexed grantId, address indexed to, uint256 amount);
	    event ReinitializeGrant(
		    uint256 indexed grantId,
		    address indexed to,
		    uint256 amount
	    );
	    event MoveGrantToNextStage(
		    uint256 indexed grantId,
		    address indexed to,
		    uint256 amount,
		    uint8 grantNumber,
		    uint8 stageNumber
	    );
	    event ReinitializeNextStage(
		    uint256 indexed grantId,
		    address indexed builder,
		    uint256 amount,
		    uint8 grantNumber,
		    uint8 stageNumber
	    );
	    event UpdateGrant(
		    uint256 indexed grantId,
		    address indexed to,
		    uint256 cap,
		    uint256 last,
		    uint256 amountLeft,
		    uint8 grantNumber,
		    uint8 stageNumber
	    );
	    event AddOwner(address indexed newOwner, address indexed addedBy);
	    event RemoveOwner(address indexed removedOwner, address indexed removedBy);
    
	    // Custom errors
	    error NoActiveStream();
	    error InsufficientContractFunds();
	    error UnauthorizedWithdrawal();
	    error InsufficientStreamFunds();
	    error FailedToSendEther();
	    error PreviousAmountNotFullyWithdrawn();
	    error AlreadyWithdrawnFromGrant();
    
	    constructor(address[] memory _initialOwners) {
		    _setRoleAdmin(OWNER_ROLE, OWNER_ROLE);
		    for (uint i = 0; i < _initialOwners.length; i++) {
			    _grantRole(OWNER_ROLE, _initialOwners[i]);
		    }
	    }
    
	    function unlockedGrantAmount(
		    uint256 _grantId
	    ) public view returns (uint256) {
		    GrantStream memory grantStream = grantStreams[_grantId];
		    if (grantStream.cap == 0) revert NoActiveStream();
    
		    if (grantStream.amountLeft == 0) {
			    return 0;
		    }
    
		    uint256 elapsedTime = block.timestamp - grantStream.last;
		    uint256 unlockedAmount = (grantStream.cap * elapsedTime) /
			    FULL_STREAM_UNLOCK_PERIOD;
    
		    return
			    unlockedAmount > grantStream.amountLeft
				    ? grantStream.amountLeft
				    : unlockedAmount;
	    }
    
	    function addGrantStream(
		    address _builder,
		    uint256 _cap,
		    uint8 _grantNumber
	    ) public onlyRole(OWNER_ROLE) returns (uint256) {
		    // check if grantStream with same grantNumber already exists
		    uint256 existingGrantId;
		    BuilderGrantData[] memory existingBuilderGrants = builderGrants[
			    _builder
		    ];
		    for (uint i = 0; i < existingBuilderGrants.length; i++) {
			    GrantStream memory existingGrant = grantStreams[
				    existingBuilderGrants[i].grantId
			    ];
			    if (existingGrant.grantNumber == _grantNumber) {
				    if (existingGrant.cap != existingGrant.amountLeft) {
					    revert AlreadyWithdrawnFromGrant();
				    }
				    existingGrantId = existingBuilderGrants[i].grantId;
				    break;
			    }
		    }
    
		    // update existing grant or create new one
		    uint256 grantId = existingGrantId != 0
			    ? existingGrantId
			    : nextGrantId++;
    
		    grantStreams[grantId] = GrantStream({
			    cap: _cap,
			    last: block.timestamp,
			    amountLeft: _cap,
			    grantNumber: _grantNumber,
			    stageNumber: 1,
			    builder: _builder
		    });
    
		    if (existingGrantId == 0) {
			    builderGrants[_builder].push(
				    BuilderGrantData({
					    grantId: grantId,
					    grantNumber: _grantNumber
				    })
			    );
			    emit AddGrant(grantId, _builder, _cap);
		    } else {
			    emit ReinitializeGrant(grantId, _builder, _cap);
		    }
		    return grantId;
	    }
    
	    function moveGrantToNextStage(
		    uint256 _grantId,
		    uint256 _cap
	    ) public onlyRole(OWNER_ROLE) {
		    GrantStream storage grantStream = grantStreams[_grantId];
		    if (grantStream.cap == 0) revert NoActiveStream();
    
		    // If amountLeft equals cap, reinitialize with same stage number
		    if (grantStream.amountLeft == grantStream.cap) {
			    grantStream.cap = _cap;
			    grantStream.last = block.timestamp;
			    grantStream.amountLeft = _cap;
			    // Stage number remains the same
			    emit ReinitializeNextStage(
				    _grantId,
				    grantStream.builder,
				    _cap,
				    grantStream.grantNumber,
				    grantStream.stageNumber
			    );
		    } else {
			    if (grantStream.amountLeft > DUST_THRESHOLD)
				    revert PreviousAmountNotFullyWithdrawn();
    
			    if (grantStream.amountLeft > 0) {
				    (bool sent, ) = payable(grantStream.builder).call{
					    value: grantStream.amountLeft
				    }("");
				    if (!sent) revert FailedToSendEther();
			    }
    
			    grantStream.cap = _cap;
			    grantStream.last = block.timestamp;
			    grantStream.amountLeft = _cap;
			    grantStream.stageNumber += 1;
    
			    emit MoveGrantToNextStage(
				    _grantId,
				    grantStream.builder,
				    _cap,
				    grantStream.grantNumber,
				    grantStream.stageNumber
			    );
		    }
	    }
    
	    function updateGrant(
		    uint256 _grantId,
		    uint256 _cap,
		    uint256 _last,
		    uint256 _amountLeft,
		    uint8 _stageNumber
	    ) public onlyRole(OWNER_ROLE) {
		    GrantStream storage grantStream = grantStreams[_grantId];
		    if (grantStream.cap == 0) revert NoActiveStream();
		    grantStream.cap = _cap;
		    grantStream.last = _last;
		    grantStream.amountLeft = _amountLeft;
		    grantStream.stageNumber = _stageNumber;
    
		    emit UpdateGrant(
			    _grantId,
			    grantStream.builder,
			    _cap,
			    grantStream.last,
			    grantStream.amountLeft,
			    grantStream.grantNumber,
			    grantStream.stageNumber
		    );
	    }
    
	    function streamWithdraw(
		    uint256 _grantId,
		    uint256 _amount,
		    string memory _reason
	    ) public {
		    if (address(this).balance < _amount) revert InsufficientContractFunds();
		    GrantStream storage grantStream = grantStreams[_grantId];
		    if (grantStream.cap == 0) revert NoActiveStream();
		    if (msg.sender != grantStream.builder) revert UnauthorizedWithdrawal();
    
		    uint256 totalAmountCanWithdraw = unlockedGrantAmount(_grantId);
		    if (totalAmountCanWithdraw < _amount) revert InsufficientStreamFunds();
    
		    uint256 elapsedTime = block.timestamp - grantStream.last;
		    uint256 timeToDeduct = (elapsedTime * _amount) / totalAmountCanWithdraw;
    
		    grantStream.last = grantStream.last + timeToDeduct;
		    grantStream.amountLeft -= _amount;
    
		    (bool sent, ) = msg.sender.call{ value: _amount }("");
		    if (!sent) revert FailedToSendEther();
    
		    emit Withdraw(
			    msg.sender,
			    _amount,
			    _reason,
			    _grantId,
			    grantStream.grantNumber,
			    grantStream.stageNumber
		    );
	    }
    
	    function getBuilderGrantCount(
		    address _builder
	    ) public view returns (uint256) {
		    return builderGrants[_builder].length;
	    }
    
	    function addOwner(address newOwner) public onlyRole(OWNER_ROLE) {
		    grantRole(OWNER_ROLE, newOwner);
		    emit AddOwner(newOwner, msg.sender);
	    }
    
	    function removeOwner(address owner) public onlyRole(OWNER_ROLE) {
		    revokeRole(OWNER_ROLE, owner);
		    emit RemoveOwner(owner, msg.sender);
	    }
    
	    function getGrantIdByBuilderAndGrantNumber(
		    address _builder,
		    uint8 _grantNumber
	    ) public view returns (uint256) {
		    for (uint256 i = 0; i < builderGrants[_builder].length; i++) {
			    if (builderGrants[_builder][i].grantNumber == _grantNumber) {
				    return builderGrants[_builder][i].grantId;
			    }
		    }
		    return 0;
	    }
    
	    receive() external payable {}
    
	    fallback() external payable {}
    }
    
    ```
    
    </details>

- Update `export const MINIMAL_VOTES_FOR_FINAL_APPROVAL = 1;`

4. scaffold.config.ts => `chains.hardhat`