### PR TITLE
Add USDC grants to admin All Grants page

### DIFF
--- a/packages/nextjs/app/_components/Grants/AllGrantsList.tsx
+++ b/packages/nextjs/app/_components/Grants/AllGrantsList.tsx
@@ -2,20 +2,18 @@
 
 import { useMemo, useState } from "react";
 import { GrantItem } from "../Grants/GrantItem";
-import { GrantWithStages } from "~~/app/grants/[grantId]/page";
+import { LargeGrantItem } from "./LargeGrantItem";
 import { Pagination } from "~~/components/pg-ens/Pagination";
+import { DiscriminatedAdminGrant } from "~~/types/utils";
 
 const GRANTS_PER_PAGE = 8;
 
-type AllGrantsListProps = {
-  allGrants: NonNullable<GrantWithStages>[];
-};
-
-export const AllGrantsList = ({ allGrants }: AllGrantsListProps) => {
+export const AllGrantsList = ({ allGrants }: { allGrants: DiscriminatedAdminGrant[] }) => {
   const [currentListPage, setCurrentListPage] = useState(1);
   const [searchQuery, setSearchQuery] = useState("");
   const [stageFilter, setStageFilter] = useState("all");
   const [statusFilter, setStatusFilter] = useState("all");
+  const [typeFilter, setTypeFilter] = useState("all");
 
   const maxStage = useMemo(() => {
     const stageNumbers = allGrants.flatMap(grant => grant.stages.map(stage => stage.stageNumber));
@@ -32,10 +30,11 @@ export const AllGrantsList = ({ allGrants }: AllGrantsListProps) => {
 
       const matchesStage = stageFilter === "all" || latestStage.stageNumber.toString() === stageFilter;
       const matchesStatus = statusFilter === "all" || latestStage.status === statusFilter;
+      const matchesType = typeFilter === "all" || grant.type === typeFilter;
 
-      return matchesSearch && matchesStage && matchesStatus;
+      return matchesSearch && matchesStage && matchesStatus && matchesType;
     });
-  }, [allGrants, searchQuery, stageFilter, statusFilter]);
+  }, [allGrants, searchQuery, stageFilter, statusFilter, typeFilter]);
 
   const currentPageGrants = filteredGrants.slice(
     (currentListPage - 1) * GRANTS_PER_PAGE,
@@ -51,6 +50,15 @@ export const AllGrantsList = ({ allGrants }: AllGrantsListProps) => {
           className="input input-bordered w-full sm:w-64"
           onChange={e => setSearchQuery(e.target.value)}
         />
+        <select
+          className="select select-bordered w-full sm:w-64"
+          value={typeFilter}
+          onChange={e => setTypeFilter(e.target.value)}
+        >
+          <option value="all">All Grants</option>
+          <option value="grant">ETH Grants</option>
+          <option value="largeGrant">USDC Grants</option>
+        </select>
         <select
           className="select select-bordered w-full sm:w-64"
           value={stageFilter}
@@ -78,8 +86,12 @@ export const AllGrantsList = ({ allGrants }: AllGrantsListProps) => {
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 sm:gap-6 xl:gap-8 w-full my-10">
         {currentPageGrants.map(grant => (
-          <div key={grant.id} className="flex justify-center">
-            <GrantItem grant={grant} latestsShownStatus="all" />
+          <div key={`${grant.type}-${grant.id}`} className="flex justify-center">
+            {grant.type === "largeGrant" ? (
+              <LargeGrantItem grant={grant} latestsShownStatus="all" />
+            ) : (
+              <GrantItem grant={grant} latestsShownStatus="all" />
+            )}
           </div>
         ))}
       </div>

--- a/packages/nextjs/app/_components/Grants/ApprovedGrantsList.tsx
+++ b/packages/nextjs/app/_components/Grants/ApprovedGrantsList.tsx
@@ -25,9 +25,9 @@ export const ApprovedGrantsList = ({ approvedGrants }: ApprovedGrantsListProps) 
       <div className="my-10 grid sm:grid-cols-2 xl:grid-cols-4 gap-8 w-full max-w-96 sm:max-w-[50rem] xl:max-w-screen-2xl">
         {currentListApprovedGrants.map(grant =>
           grant.type === "largeGrant" ? (
-            <LargeGrantItem key={grant.id} grant={grant} latestsShownStatus="approved" />
+            <LargeGrantItem key={`${grant.type}-${grant.id}`} grant={grant} latestsShownStatus="approved" />
           ) : (
-            <GrantItem key={grant.id} grant={grant} latestsShownStatus="approved" />
+            <GrantItem key={`${grant.type}-${grant.id}`} grant={grant} latestsShownStatus="approved" />
           ),
         )}
       </div>

--- a/packages/nextjs/app/all-grants/page.tsx
+++ b/packages/nextjs/app/all-grants/page.tsx
@@ -3,6 +3,8 @@ import { getServerSession } from "next-auth/next";
 import { AllGrantsList } from "~~/app/_components/Grants/AllGrantsList";
 import { SignInBtn } from "~~/components/pg-ens/SignInBtn";
 import { getAllGrants } from "~~/services/database/repositories/grants";
+import { getAllLargeGrants } from "~~/services/database/repositories/large-grants";
+import { DiscriminatedAdminGrant } from "~~/types/utils";
 import { authOptions } from "~~/utils/auth";
 
 export const revalidate = 0;
@@ -24,7 +26,15 @@ export default async function AllGrantsPage() {
     return redirect("/");
   }
 
-  const allGrants = await getAllGrants();
+  const grants: DiscriminatedAdminGrant[] = (await getAllGrants()).map(grant => ({ ...grant, type: "grant" }));
+  const largeGrants: DiscriminatedAdminGrant[] = (await getAllLargeGrants()).map(grant => ({
+    ...grant,
+    type: "largeGrant",
+  }));
+
+  const allGrants: DiscriminatedAdminGrant[] = [...grants, ...largeGrants].sort(
+    (a, b) => (b.submitedAt?.getTime() ?? 0) - (a.submitedAt?.getTime() ?? 0),
+  );
 
   return (
     <div className="py-10 px-4 flex flex-col items-center w-full">

--- a/packages/nextjs/services/database/repositories/large-grants.ts
+++ b/packages/nextjs/services/database/repositories/large-grants.ts
@@ -9,7 +9,6 @@ export type LargeGrantInsertWithMilestones = LargeGrantInsert & {
 export type LargeGrant = InferSelectModel<typeof largeGrants>;
 export type PublicLargeGrant = Awaited<ReturnType<typeof getPublicLargeGrants>>[number];
 
-// Note: not used yet
 export async function getAllLargeGrants() {
   return await db.query.largeGrants.findMany({
     orderBy: [desc(largeGrants.submitedAt)],
@@ -17,6 +16,11 @@ export async function getAllLargeGrants() {
       stages: {
         // this makes sure latest stage is first
         orderBy: [desc(largeStages.stageNumber)],
+        with: {
+          milestones: {
+            orderBy: [desc(largeMilestones.milestoneNumber)],
+          },
+        },
       },
     },
   });

--- a/packages/nextjs/types/utils.ts
+++ b/packages/nextjs/types/utils.ts
@@ -1,5 +1,9 @@
-import { PublicGrant, getBuilderGrants } from "~~/services/database/repositories/grants";
-import { PublicLargeGrant, getBuilderLargeGrants } from "~~/services/database/repositories/large-grants";
+import { PublicGrant, getAllGrants, getBuilderGrants } from "~~/services/database/repositories/grants";
+import {
+  PublicLargeGrant,
+  getAllLargeGrants,
+  getBuilderLargeGrants,
+} from "~~/services/database/repositories/large-grants";
 
 export type Tuple<T, MaxLength extends number = 10, Current extends T[] = []> = Current["length"] extends MaxLength
   ? Current
@@ -16,3 +20,10 @@ export type BuilderLargeGrant = Awaited<ReturnType<typeof getBuilderLargeGrants>
 export type DiscriminatedBuilderGrant =
   | (BuilderGrant & { type: "grant" })
   | (BuilderLargeGrant & { type: "largeGrant" });
+
+export type AdminGrant = Awaited<ReturnType<typeof getAllGrants>>[0];
+
+export type AdminLargeGrant = Awaited<ReturnType<typeof getAllLargeGrants>>[0];
+
+// Add a discriminator property to distinguish between Grant and LargeGrant
+export type DiscriminatedAdminGrant = (AdminGrant & { type: "grant" }) | (AdminLargeGrant & { type: "largeGrant" });


### PR DESCRIPTION
It was implemented in the same way as ETH grants. Maybe in the future, we should implement the filters on the DB layer to avoid getting all the grants (it depends on how many grants are expected to be received).

A new filter for ETH or USDC grants was added.

![localhost_3000_all-grants](https://github.com/user-attachments/assets/5fb7fded-9cb4-4602-9540-7616a71b0ebc)

closes #39 