### PR TITLE
Datepicker styles

### DIFF
--- a/packages/nextjs/components/pg-ens/form-fields/FormInputDate.tsx
+++ b/packages/nextjs/components/pg-ens/form-fields/FormInputDate.tsx
@@ -24,6 +24,7 @@ export const FormInputDate = ({ error, label, name, required }: FormInputProps) 
         selected={dateValue ? new Date(dateValue) : null}
         onChange={date => setValue(name, date)}
         className={`input input-bordered mt-1 w-full${error ? " input-error" : ""}`}
+        disabledKeyboardNavigation
       />
       <FormErrorMessage error={error} />
     </div>

--- a/packages/nextjs/styles/globals.css
+++ b/packages/nextjs/styles/globals.css
@@ -47,3 +47,46 @@ p {
 .btn.btn-ghost {
   @apply shadow-none;
 }
+
+/* Datepicker styling */
+.react-datepicker__day--selected {
+  background-color: #af52de !important;
+  color: white !important;
+}
+
+.react-datepicker__day--selected:hover,
+.react-datepicker__day:hover {
+  background-color: #af52de !important;
+  opacity: 0.8;
+  color: white !important;
+}
+
+.react-datepicker__day--keyboard-selected {
+  background-color: #af52de !important;
+  color: white !important;
+}
+
+/* Force white text color for selected date */
+.react-datepicker__day.react-datepicker__day--selected {
+  color: white !important;
+}
+
+.react-datepicker__day--today {
+  color: #af52de !important;
+  font-weight: bold;
+}
+
+.react-datepicker__day--today:hover {
+  color: white !important;
+}
+
+.react-datepicker__day--selected.react-datepicker__day--outside-month {
+  color: white !important;
+}
+
+/* Header styling */
+.react-datepicker__header {
+  background-color: #f3e6fb !important;
+  border-bottom: 1px solid #f3e6fb !important;
+}
+/* End of datepicker styling */


### PR DESCRIPTION
https://github.com/user-attachments/assets/bada186e-f8ba-4a7c-8c9b-1b3aac14e3b6

Note: disabled keyboard navigation because it chose the same date for each month and you could see something like this:

<img width="204" alt="Screenshot 2025-03-26 at 16 38 31" src="https://github.com/user-attachments/assets/3a346a72-aedc-429a-9c93-fc134c788184" />

Fixes #36 