### PR TITLE
Add large grants to admin approval page

### DIFF
--- a/packages/nextjs/app/_components/Grants/LargeGrantItem.tsx
+++ b/packages/nextjs/app/_components/Grants/LargeGrantItem.tsx
@@ -35,6 +35,7 @@ export const LargeGrantItem = ({ grant, latestsShownStatus }: GrantItemProps) =>
     (latestStage.status === "proposed" || latestStage.status === "rejected");
 
   const allMilestonesGrantAmount = grant.stages
+    .filter(stage => stage.status !== "proposed" && stage.status !== "rejected")
     .flatMap(stage => stage.milestones)
     .reduce((acc, current) => acc + current.amount, 0);
 

--- a/packages/nextjs/app/_components/Grants/LargeGrantItem.tsx
+++ b/packages/nextjs/app/_components/Grants/LargeGrantItem.tsx
@@ -57,7 +57,7 @@ export const LargeGrantItem = ({ grant, latestsShownStatus }: GrantItemProps) =>
       <div className="px-4 py-8 bg-gray-100 mb-0 shadow-sm">
         <div className="flex items-start mb-6">
           {isAdmin ? (
-            <Link href={`/grants/${grant.id}`} className="hover:underline flex items-start">
+            <Link href={`/large-grants/${grant.id}`} className="hover:underline flex items-start">
               <h2 className="text-2xl font-bold pr-2 flex-grow">{grant.title}</h2>
               <MagnifyingGlassIcon className="flex-shrink-0 w-6 h-6 text-gray-500 mt-1" />
             </Link>

--- a/packages/nextjs/app/_components/stats/LargeGrantsStats.tsx
+++ b/packages/nextjs/app/_components/stats/LargeGrantsStats.tsx
@@ -2,14 +2,14 @@ import { StatsItem } from "./StatsItem";
 import { getLargeGrantsStats } from "~~/services/database/repositories/large-grants";
 
 export const LargeGrantsStats = async () => {
-  const { totalUsdcGranted, allGrantsCount, proposedLargeGrantsCount } = await getLargeGrantsStats();
+  const { totalUsdcGranted, allGrantsCount, approvedLargeGrantsCount } = await getLargeGrantsStats();
 
   return (
     <div className="inline-flex justify-center items-center gap-2 bg-white rounded-lg overflow-hidden">
       <StatsItem value={totalUsdcGranted} description="USDC granted" large />
       <div className="flex flex-col gap-1">
-        <StatsItem value={allGrantsCount} description="Large Grants" large secondary />
-        <StatsItem value={proposedLargeGrantsCount} description="Proposals" large secondary />
+        <StatsItem value={approvedLargeGrantsCount} description="Large Grants" large secondary />
+        <StatsItem value={allGrantsCount} description="Proposals" large secondary />
       </div>
     </div>
   );

--- a/packages/nextjs/app/admin/_components/LargeGrantApprovalVoteModal/index.tsx
+++ b/packages/nextjs/app/admin/_components/LargeGrantApprovalVoteModal/index.tsx
@@ -49,29 +49,39 @@ export const LargeGrantApprovalVoteModal = forwardRef<HTMLDialogElement, Approva
 
     return (
       <dialog id="action_modal" className="modal" ref={ref}>
-        <div className="modal-box flex flex-col space-y-3">
+        <div className="modal-box flex flex-col space-y-6">
           <form method="dialog" className="bg-secondary -mx-6 -mt-6 px-6 py-4 flex items-center justify-between">
             <div className="flex justify-between items-center">
               <p className="font-bold text-xl m-0">
-                Approval vote for Stage {stage.stageNumber} of {grantName}
+                {stage.stageNumber > 1 ? `Stage ${stage.stageNumber} of ${grantName}` : grantName}
               </p>
             </div>
             {/* if there is a button in form, it will close the modal */}
             <button className="btn btn-sm btn-circle btn-ghost text-xl h-auto">✕</button>
           </form>
-          <span className="text-sm">
-            <p>This grant doesn&apos;t meet the approval threshold to setup contract yet.</p>
-          </span>
-          <Button
-            type="submit"
-            variant="green-secondary"
-            disabled={isPostingApprovalVote || isSigning}
-            className="self-center"
-            onClick={onSubmit}
-          >
-            {(isPostingApprovalVote || isSigning) && <span className="loading loading-spinner"></span>}
-            Vote for approval
-          </Button>
+          <div>Are you sure you want to vote for the approval of this {stage.stageNumber > 1 ? "stage" : "grant"}?</div>
+          <div className="flex justify-between">
+            <Button
+              variant="secondary"
+              size="sm"
+              disabled={isPostingApprovalVote || isSigning}
+              className="self-center"
+              onClick={closeModal}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="green-secondary"
+              size="sm"
+              disabled={isPostingApprovalVote || isSigning}
+              className="self-center"
+              onClick={onSubmit}
+            >
+              {(isPostingApprovalVote || isSigning) && <span className="loading loading-spinner"></span>}
+              Vote for approval
+            </Button>
+          </div>
         </div>
         <Toaster />
       </dialog>

--- a/packages/nextjs/app/admin/_components/LargeGrantApprovalVoteModal/index.tsx
+++ b/packages/nextjs/app/admin/_components/LargeGrantApprovalVoteModal/index.tsx
@@ -1,0 +1,82 @@
+import { forwardRef } from "react";
+import { useRouter } from "next/navigation";
+import { LargeGrantWithStagesAndPrivateNotes } from "../LargeGrantProposal";
+import { useMutation } from "@tanstack/react-query";
+import { Toaster } from "react-hot-toast";
+import { useSignTypedData } from "wagmi";
+import { ApprovalVoteReqBody } from "~~/app/api/large-stages/[stageId]/approval-vote/route";
+import { Button } from "~~/components/pg-ens/Button";
+import { EIP_712_DOMAIN, EIP_712_TYPES__LARGE_STAGE_APPROVAL_VOTE } from "~~/utils/eip712";
+import { postMutationFetcher } from "~~/utils/react-query";
+import { getParsedError, notification } from "~~/utils/scaffold-eth";
+
+type ApprovalVoteModalProps = {
+  stage: LargeGrantWithStagesAndPrivateNotes["stages"][number];
+  grantName: string;
+  closeModal: () => void;
+};
+
+export const LargeGrantApprovalVoteModal = forwardRef<HTMLDialogElement, ApprovalVoteModalProps>(
+  ({ stage, grantName, closeModal }, ref) => {
+    const router = useRouter();
+
+    const { signTypedDataAsync, isPending: isSigning } = useSignTypedData();
+
+    const { mutateAsync: postApprovalVote, isPending: isPostingApprovalVote } = useMutation({
+      mutationFn: (approvalVoteBody: ApprovalVoteReqBody) =>
+        postMutationFetcher(`/api/large-stages/${stage.id}/approval-vote`, { body: approvalVoteBody }),
+    });
+
+    const onSubmit = async () => {
+      try {
+        const signature = await signTypedDataAsync({
+          domain: EIP_712_DOMAIN,
+          types: EIP_712_TYPES__LARGE_STAGE_APPROVAL_VOTE,
+          primaryType: "Message",
+          message: {
+            stageId: String(stage.id),
+          },
+        });
+
+        await postApprovalVote({ signature });
+        closeModal();
+        router.refresh();
+      } catch (error) {
+        const errorMessage = getParsedError(error);
+        notification.error(errorMessage);
+      }
+    };
+
+    return (
+      <dialog id="action_modal" className="modal" ref={ref}>
+        <div className="modal-box flex flex-col space-y-3">
+          <form method="dialog" className="bg-secondary -mx-6 -mt-6 px-6 py-4 flex items-center justify-between">
+            <div className="flex justify-between items-center">
+              <p className="font-bold text-xl m-0">
+                Approval vote for Stage {stage.stageNumber} of {grantName}
+              </p>
+            </div>
+            {/* if there is a button in form, it will close the modal */}
+            <button className="btn btn-sm btn-circle btn-ghost text-xl h-auto">✕</button>
+          </form>
+          <span className="text-sm">
+            <p>This grant doesn&apos;t meet the approval threshold to setup contract yet.</p>
+          </span>
+          <Button
+            type="submit"
+            variant="green-secondary"
+            disabled={isPostingApprovalVote || isSigning}
+            className="self-center"
+            onClick={onSubmit}
+          >
+            {(isPostingApprovalVote || isSigning) && <span className="loading loading-spinner"></span>}
+            Vote for approval
+          </Button>
+        </div>
+        <Toaster />
+      </dialog>
+    );
+  },
+);
+
+LargeGrantApprovalVoteModal.displayName = "LargeGrantApprovalVoteModal";

--- a/packages/nextjs/app/admin/_components/LargeGrantFinalApproveModal/index.tsx
+++ b/packages/nextjs/app/admin/_components/LargeGrantFinalApproveModal/index.tsx
@@ -1,0 +1,160 @@
+import { forwardRef, useState } from "react";
+import { FinalApproveModalFormValues, finalApproveModalFormSchema } from "./schema";
+import { FormProvider } from "react-hook-form";
+import { Toaster } from "react-hot-toast";
+import { parseUnits } from "viem";
+import { Button } from "~~/components/pg-ens/Button";
+import { FormTextarea } from "~~/components/pg-ens/form-fields/FormTextarea";
+import { Address } from "~~/components/scaffold-eth";
+import { useFormMethods } from "~~/hooks/pg-ens/useFormMethods";
+import { useLargeStageReview } from "~~/hooks/pg-ens/useLargeStageReview";
+import { useScaffoldReadContract, useScaffoldWriteContract } from "~~/hooks/scaffold-eth";
+import { LargeGrantWithStagesAndPrivateNotes } from "~~/types/utils";
+import { notification } from "~~/utils/scaffold-eth";
+
+const LOADING_STATUS_MAP = {
+  CreatingGrant: "Creating grant in contract",
+  Approving: "Approving grant",
+  MovingToNextStage: "Moving grant to next stage",
+  Empty: "",
+} as const;
+
+const WAITING_FOR_SIGNATURE_POSTFIX = "waiting for signature";
+
+type LoadingStatus = (typeof LOADING_STATUS_MAP)[keyof typeof LOADING_STATUS_MAP];
+
+const getLoadingStatusText = ({ status, isWaiting }: { status: LoadingStatus; isWaiting: boolean }) => {
+  if (status === LOADING_STATUS_MAP.Empty) {
+    return status;
+  }
+
+  if (isWaiting) {
+    return `${status}, ${WAITING_FOR_SIGNATURE_POSTFIX}...`;
+  }
+
+  return `${status}...`;
+};
+
+export const LargeGrantFinalApproveModal = forwardRef<
+  HTMLDialogElement,
+  {
+    stage: LargeGrantWithStagesAndPrivateNotes["stages"][number];
+    grantName: string;
+    builderAddress: string;
+    isGrant?: boolean;
+    grantId: number;
+  }
+>(({ stage, grantName, builderAddress, isGrant, grantId }, ref) => {
+  const { reviewStage, isSigning } = useLargeStageReview(stage.id);
+  const [loadingStatus, setLoadingStatus] = useState<LoadingStatus>(LOADING_STATUS_MAP.Empty);
+  const { approvalVotes } = stage;
+
+  const { getCommonOptions, formMethods } = useFormMethods<FinalApproveModalFormValues>({
+    schema: finalApproveModalFormSchema,
+  });
+
+  const { handleSubmit } = formMethods;
+
+  const { writeContractAsync, isPending: isWriteContractPending } = useScaffoldWriteContract("LargeGrant");
+
+  const { data: contractGrantIdForBuilder } = useScaffoldReadContract({
+    contractName: "LargeGrant",
+    functionName: "grantData",
+    args: [BigInt(grantId)],
+    query: {
+      enabled: !isGrant,
+    },
+  });
+
+  const handleCreateGrant = async () => {
+    try {
+      let txHash;
+
+      const milestoneAmounts = stage.milestones.map(milestone => parseUnits(milestone.amount.toString(), 6));
+
+      if (isGrant) {
+        setLoadingStatus(LOADING_STATUS_MAP.CreatingGrant);
+        txHash = await writeContractAsync({
+          functionName: "addGrant",
+          args: [builderAddress as `0x${string}`, BigInt(grantId), milestoneAmounts],
+        });
+      } else {
+        if (!contractGrantIdForBuilder) {
+          setLoadingStatus(LOADING_STATUS_MAP.Empty);
+
+          return notification.error("Error getting grant for corresponding builder in contract");
+        }
+        setLoadingStatus(LOADING_STATUS_MAP.MovingToNextStage);
+
+        txHash = await writeContractAsync({
+          functionName: "addGrantStage",
+          args: [BigInt(grantId), milestoneAmounts],
+        });
+      }
+
+      return txHash;
+    } catch (e) {
+      console.error("Error sending setup transaction", e);
+    }
+  };
+
+  const onSubmit = async (fieldValues: FinalApproveModalFormValues) => {
+    const txHash = await handleCreateGrant();
+    if (!txHash) {
+      setLoadingStatus(LOADING_STATUS_MAP.Empty);
+      return notification.error("Error setting up stream");
+    }
+    setLoadingStatus(LOADING_STATUS_MAP.Approving);
+    await reviewStage({ status: "approved", ...fieldValues, txHash });
+    setLoadingStatus(LOADING_STATUS_MAP.Empty);
+  };
+
+  const loadingStatusText = getLoadingStatusText({
+    status: loadingStatus,
+    isWaiting: isSigning || isWriteContractPending,
+  });
+
+  return (
+    <dialog id="action_modal" className="modal" ref={ref}>
+      <div className="modal-box flex flex-col space-y-3">
+        <form method="dialog" className="bg-secondary -mx-6 -mt-6 px-6 py-4 flex items-center justify-between">
+          <div className="flex justify-between items-center">
+            <p className="font-bold text-xl m-0">
+              Approve Stage {stage.stageNumber} for {grantName}
+            </p>
+          </div>
+          <button className="btn btn-sm btn-circle btn-ghost text-xl h-auto">✕</button>
+        </form>
+        <FormProvider {...formMethods}>
+          {approvalVotes.length > 0 && (
+            <>
+              <div className="font-bold">Pre-approved by:</div>
+
+              {approvalVotes.map(approvalVote => (
+                <div key={approvalVote.id} className="flex items-center gap-2">
+                  <Address address={approvalVote.authorAddress as `0x${string}`} />
+                </div>
+              ))}
+              <div className="divider" />
+            </>
+          )}
+          <form onSubmit={handleSubmit(onSubmit)} className="w-full flex flex-col gap-1">
+            <FormTextarea label="Note (visible to grantee)" {...getCommonOptions("statusNote")} />
+            {loadingStatusText && (
+              <div className="text-xl flex justify-center items-center gap-2 my-2">
+                <span className="loading loading-spinner" />
+                {loadingStatusText}
+              </div>
+            )}
+            <Button variant="green" type="submit" className="!px-4 self-center" disabled={Boolean(loadingStatus)}>
+              <span>Final Approve</span>
+            </Button>
+          </form>
+        </FormProvider>
+      </div>
+      <Toaster />
+    </dialog>
+  );
+});
+
+LargeGrantFinalApproveModal.displayName = "LargeGrantFinalApproveModal";

--- a/packages/nextjs/app/admin/_components/LargeGrantFinalApproveModal/schema.tsx
+++ b/packages/nextjs/app/admin/_components/LargeGrantFinalApproveModal/schema.tsx
@@ -1,0 +1,8 @@
+import * as z from "zod";
+import { DEFAULT_TEXTAREA_MAX_LENGTH } from "~~/utils/forms";
+
+export const finalApproveModalFormSchema = z.object({
+  statusNote: z.string().max(DEFAULT_TEXTAREA_MAX_LENGTH).optional(),
+});
+
+export type FinalApproveModalFormValues = z.infer<typeof finalApproveModalFormSchema>;

--- a/packages/nextjs/app/admin/_components/LargeGrantProposal.tsx
+++ b/packages/nextjs/app/admin/_components/LargeGrantProposal.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { LargeGrantApprovalVoteModal } from "./LargeGrantApprovalVoteModal";
+import { LargeGrantFinalApproveModal } from "./LargeGrantFinalApproveModal";
+import { LargeRejectModal } from "./LargeRejectModal";
+import { PrivateNoteModal } from "./PrivateNoteModal";
+import { useAccount } from "wagmi";
+import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/outline";
+import { Button } from "~~/components/pg-ens/Button";
+import { FormErrorMessage } from "~~/components/pg-ens/form-fields/FormErrorMessage";
+import { Address } from "~~/components/scaffold-eth";
+import { getAllLargeGrantsWithStagesAndPrivateNotes } from "~~/services/database/repositories/large-grants";
+import { MINIMAL_VOTES_FOR_FINAL_APPROVAL } from "~~/utils/approval-votes";
+import { getFormattedDate } from "~~/utils/getFormattedDate";
+import { multilineStringToTsx } from "~~/utils/multiline-string-to-tsx";
+
+function isElementClamped(element: HTMLElement | null) {
+  if (!element) return false;
+  return element.scrollHeight > element.clientHeight;
+}
+
+export type LargeGrantWithStagesAndPrivateNotes = Awaited<
+  ReturnType<typeof getAllLargeGrantsWithStagesAndPrivateNotes>
+>[0];
+
+type ProposalProps = {
+  proposal: LargeGrantWithStagesAndPrivateNotes;
+  userSubmissionsAmount: number;
+  isGrant?: boolean;
+};
+
+export const LargeGrantProposal = ({ proposal, userSubmissionsAmount, isGrant }: ProposalProps) => {
+  const milesonesRef = useRef<HTMLDivElement>(null);
+  const [isDefaultExpanded, setIsDefaultExpanded] = useState(true);
+  const [isExpandedByClick, setIsExpandedByClick] = useState(false);
+  const [canVote, setCanVote] = useState(true);
+  const { address } = useAccount();
+
+  const privateNoteModalRef = useRef<HTMLDialogElement>(null);
+  const finalApproveModalRef = useRef<HTMLDialogElement>(null);
+  const approvalVoteModalRef = useRef<HTMLDialogElement>(null);
+  const rejectModalRef = useRef<HTMLDialogElement>(null);
+
+  const latestStage = proposal.stages[0];
+  const { privateNotes, approvalVotes } = latestStage;
+
+  const isFinalApproveAvailable = approvalVotes && approvalVotes.length >= MINIMAL_VOTES_FOR_FINAL_APPROVAL;
+
+  const milestonesToShow = latestStage.milestones;
+
+  const totalAmount = milestonesToShow.reduce((acc, milestone) => acc + milestone.amount, 0);
+
+  useEffect(() => {
+    // waits for render to calculate
+    setIsDefaultExpanded(!isElementClamped(milesonesRef.current));
+  }, []);
+
+  useEffect(() => {
+    setCanVote(!approvalVotes || approvalVotes.every(vote => vote.authorAddress !== address));
+  }, [approvalVotes, address]);
+
+  return (
+    <div className="card bg-white text-primary-content w-full max-w-lg shadow-center">
+      <div className="px-5 py-3 flex justify-between items-center w-full">
+        <div className="font-bold text-xl">Stage {latestStage.stageNumber}</div>
+        <div>{getFormattedDate(latestStage.submitedAt as Date)}</div>
+      </div>
+      <div className="px-5 py-8 bg-gray-100">
+        <h2 className="text-2xl font-bold mb-0">{proposal.title}</h2>
+        <Link
+          href={`/large-grants/${proposal.id}`}
+          className="text-gray-500 underline flex items-center gap-1"
+          target="_blank"
+        >
+          View grant page <ArrowTopRightOnSquareIcon className="w-5 h-5" />
+        </Link>
+        <div className="mt-6 flex flex-col lg:flex-row gap-1">
+          <Address address={proposal.builderAddress as `0x${string}`} />
+          <span className="hidden lg:inline">·</span>
+          <Link
+            href={`/builder-grants/${proposal.builderAddress}`}
+            className="text-gray-500 underline flex items-center gap-1"
+            target="_blank"
+          >
+            <span>
+              {userSubmissionsAmount} submission{userSubmissionsAmount === 1 ? "" : "s"}
+            </span>
+            <ArrowTopRightOnSquareIcon className="w-5 h-5" />
+          </Link>
+        </div>
+      </div>
+
+      <div className="p-5">
+        <div className="inline-block px-2 font-semibold bg-gray-100 rounded-sm">
+          Initial grant request: {totalAmount.toLocaleString()} USDC
+        </div>
+
+        <div className="mt-2">
+          <div className={isExpandedByClick ? "" : "line-clamp-1"} ref={milesonesRef}>
+            <div className="font-semibold">
+              {latestStage.stageNumber > 1 ? "Stage milestones:" : "Planned milestones:"}
+            </div>
+
+            {milestonesToShow.map((milestone, index) => (
+              <div key={milestone.id} className="mt-1 first:mt-0">
+                <div className="font-semibold">Milestone {index + 1}</div>
+                <div>{multilineStringToTsx(milestone.description)}</div>
+                <div>{milestone.amount.toLocaleString()} USDC</div>
+              </div>
+            ))}
+          </div>
+          {!isDefaultExpanded && !isExpandedByClick && milestonesToShow && (
+            <button className="bg-transparent font-semibold underline" onClick={() => setIsExpandedByClick(true)}>
+              Show Milestones
+            </button>
+          )}
+        </div>
+
+        <div className="flex flex-col lg:flex-row-reverse lg:items-start justify-between gap-3 mt-4">
+          <div className="flex flex-col lg:flex-row lg:items-start gap-3">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => privateNoteModalRef && privateNoteModalRef.current?.showModal()}
+            >
+              Set private note
+            </Button>
+
+            {isFinalApproveAvailable ? (
+              <Button
+                variant="green"
+                size="sm"
+                onClick={() => finalApproveModalRef && finalApproveModalRef.current?.showModal()}
+              >
+                Final Approve
+              </Button>
+            ) : (
+              <div className="flex flex-col gap-1">
+                <Button
+                  variant="green-secondary"
+                  size="sm"
+                  onClick={() => approvalVoteModalRef && approvalVoteModalRef.current?.showModal()}
+                  disabled={!canVote}
+                >
+                  Vote for approval
+                </Button>
+                {!canVote && <FormErrorMessage error="Already voted" className="text-center" />}
+              </div>
+            )}
+          </div>
+          <Button
+            variant="red-secondary"
+            size="sm"
+            onClick={() => rejectModalRef && rejectModalRef.current?.showModal()}
+          >
+            Reject
+          </Button>
+        </div>
+
+        {privateNotes?.length > 0 && (
+          <div className="mt-5 pt-3 border-t border-gray-200">
+            {privateNotes.map(privateNote => (
+              <div key={privateNote.id} className="mt-1 first:mt-0 text-gray-400">
+                <div className="flex gap-1">
+                  <Address address={privateNote.authorAddress as `0x${string}`} /> :
+                </div>
+                <div className="ml-[30px]">{multilineStringToTsx(privateNote.note)}</div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <LargeGrantFinalApproveModal
+        ref={finalApproveModalRef}
+        stage={proposal.stages[0]}
+        builderAddress={proposal.builderAddress}
+        grantName={proposal.title}
+        isGrant={isGrant}
+        grantId={proposal.id}
+      />
+      <LargeGrantApprovalVoteModal
+        ref={approvalVoteModalRef}
+        stage={latestStage}
+        grantName={proposal.title}
+        closeModal={() => approvalVoteModalRef.current?.close()}
+      />
+      <LargeRejectModal ref={rejectModalRef} stage={latestStage} grantName={proposal.title} />
+      <PrivateNoteModal
+        ref={privateNoteModalRef}
+        stage={latestStage}
+        grantName={proposal.title}
+        isLargeGrant={true}
+        closeModal={() => privateNoteModalRef.current?.close()}
+      />
+    </div>
+  );
+};

--- a/packages/nextjs/app/admin/_components/LargeGrantProposal.tsx
+++ b/packages/nextjs/app/admin/_components/LargeGrantProposal.tsx
@@ -64,7 +64,10 @@ export const LargeGrantProposal = ({ proposal, userSubmissionsAmount, isGrant }:
   return (
     <div className="card bg-white text-primary-content w-full max-w-lg shadow-center">
       <div className="px-5 py-3 flex justify-between items-center w-full">
-        <div className="font-bold text-xl">Stage {latestStage.stageNumber}</div>
+        <div className="font-bold text-xl flex items-center">
+          <div className="rounded-full bg-primary h-3.5 w-3.5 mr-2" />
+          Stage {latestStage.stageNumber}
+        </div>
         <div>{getFormattedDate(latestStage.submitedAt as Date)}</div>
       </div>
       <div className="px-5 py-8 bg-gray-100">

--- a/packages/nextjs/app/admin/_components/LargeGrantProposal.tsx
+++ b/packages/nextjs/app/admin/_components/LargeGrantProposal.tsx
@@ -81,17 +81,21 @@ export const LargeGrantProposal = ({ proposal, userSubmissionsAmount, isGrant }:
         </Link>
         <div className="mt-6 flex flex-col lg:flex-row gap-1">
           <Address address={proposal.builderAddress as `0x${string}`} />
-          <span className="hidden lg:inline">·</span>
-          <Link
-            href={`/builder-grants/${proposal.builderAddress}`}
-            className="text-gray-500 underline flex items-center gap-1"
-            target="_blank"
-          >
-            <span>
-              {userSubmissionsAmount} submission{userSubmissionsAmount === 1 ? "" : "s"}
-            </span>
-            <ArrowTopRightOnSquareIcon className="w-5 h-5" />
-          </Link>
+          {latestStage.stageNumber === 1 && (
+            <>
+              <span className="hidden lg:inline">·</span>
+              <Link
+                href={`/builder-grants/${proposal.builderAddress}`}
+                className="text-gray-500 underline flex items-center gap-1"
+                target="_blank"
+              >
+                <span>
+                  {userSubmissionsAmount} submission{userSubmissionsAmount === 1 ? "" : "s"}
+                </span>
+                <ArrowTopRightOnSquareIcon className="w-5 h-5" />
+              </Link>
+            </>
+          )}
         </div>
       </div>
 

--- a/packages/nextjs/app/admin/_components/LargeGrantProposal.tsx
+++ b/packages/nextjs/app/admin/_components/LargeGrantProposal.tsx
@@ -65,7 +65,7 @@ export const LargeGrantProposal = ({ proposal, userSubmissionsAmount, isGrant }:
     <div className="card bg-white text-primary-content w-full max-w-lg shadow-center">
       <div className="px-5 py-3 flex justify-between items-center w-full">
         <div className="font-bold text-xl flex items-center">
-          <div className="rounded-full bg-primary h-3.5 w-3.5 mr-2" />
+          <div className="rounded-full bg-primary h-3.5 w-3.5 min-w-3.5 mr-2" />
           Stage {latestStage.stageNumber}
         </div>
         <div>{getFormattedDate(latestStage.submitedAt as Date)}</div>

--- a/packages/nextjs/app/admin/_components/LargeMilestoneApprovalModal/index.tsx
+++ b/packages/nextjs/app/admin/_components/LargeMilestoneApprovalModal/index.tsx
@@ -161,6 +161,7 @@ export const LargeMilestoneApprovalModal = forwardRef<
               <Button
                 variant="secondary"
                 size="sm"
+                type="button"
                 disabled={Boolean(loadingStatus)}
                 className="self-center"
                 onClick={closeModal}

--- a/packages/nextjs/app/admin/_components/LargeMilestoneApprovalModal/index.tsx
+++ b/packages/nextjs/app/admin/_components/LargeMilestoneApprovalModal/index.tsx
@@ -1,4 +1,5 @@
 import { forwardRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import { FinalApproveModalFormValues, finalApproveModalFormSchema } from "../LargeGrantFinalApproveModal/schema";
 import { LargeMilestoneWithRelatedData } from "../LargeMilestoneCompleted";
 import { FormProvider } from "react-hook-form";
@@ -37,10 +38,12 @@ export const LargeMilestoneApprovalModal = forwardRef<
   HTMLDialogElement,
   {
     milestone: LargeMilestoneWithRelatedData;
+    closeModal: () => void;
   }
->(({ milestone }, ref) => {
+>(({ milestone, closeModal }, ref) => {
   const { reviewMilestone, isSigning } = useLargeMilestoneReview(milestone.id);
   const [loadingStatus, setLoadingStatus] = useState<LoadingStatus>(LOADING_STATUS_MAP.Empty);
+  const router = useRouter();
 
   const { getCommonOptions, formMethods } = useFormMethods<FinalApproveModalFormValues>({
     schema: finalApproveModalFormSchema,
@@ -96,6 +99,8 @@ export const LargeMilestoneApprovalModal = forwardRef<
       await reviewMilestone({ status: "verified", ...fieldValues, txHash });
       setLoadingStatus(LOADING_STATUS_MAP.Empty);
     }
+    closeModal();
+    router.refresh();
   };
 
   const loadingStatusText = getLoadingStatusText({

--- a/packages/nextjs/app/admin/_components/LargeMilestoneApprovalModal/index.tsx
+++ b/packages/nextjs/app/admin/_components/LargeMilestoneApprovalModal/index.tsx
@@ -125,7 +125,7 @@ export const LargeMilestoneApprovalModal = forwardRef<
 
   return (
     <dialog id="action_modal" className="modal" ref={ref}>
-      <div className="modal-box flex flex-col space-y-3">
+      <div className="modal-box flex flex-col space-y-6">
         <form method="dialog" className="bg-secondary -mx-6 -mt-6 px-6 py-4 flex items-center justify-between">
           <div className="flex justify-between items-center">
             <p className="font-bold text-xl m-0">
@@ -145,9 +145,11 @@ export const LargeMilestoneApprovalModal = forwardRef<
               <div className="divider" />
             </>
           )}
-          <form onSubmit={handleSubmit(onSubmit)} className="w-full flex flex-col gap-1">
-            {milestone.status === "verified" && (
+          <form onSubmit={handleSubmit(onSubmit)} className="w-full flex flex-col gap-1 space-y-6">
+            {milestone.status === "verified" ? (
               <FormTextarea label="Note (visible to grantee)" {...getCommonOptions("statusNote")} />
+            ) : (
+              <div>Are you sure you want to vote for the approval of this milestone?</div>
             )}
             {loadingStatusText && (
               <div className="text-xl flex justify-center items-center gap-2 my-2">
@@ -155,9 +157,20 @@ export const LargeMilestoneApprovalModal = forwardRef<
                 {loadingStatusText}
               </div>
             )}
-            <Button variant="green" type="submit" className="!px-4 self-center" disabled={Boolean(loadingStatus)}>
-              <span>{milestone.status === "verified" ? "Final Approve" : "Approve"}</span>
-            </Button>
+            <div className="flex justify-between">
+              <Button
+                variant="secondary"
+                size="sm"
+                disabled={Boolean(loadingStatus)}
+                className="self-center"
+                onClick={closeModal}
+              >
+                Cancel
+              </Button>
+              <Button variant="green" type="submit" className="!px-4 self-center" disabled={Boolean(loadingStatus)}>
+                <span>{milestone.status === "verified" ? "Final Approve" : "Approve"}</span>
+              </Button>
+            </div>
           </form>
         </FormProvider>
       </div>

--- a/packages/nextjs/app/admin/_components/LargeMilestoneApprovalModal/index.tsx
+++ b/packages/nextjs/app/admin/_components/LargeMilestoneApprovalModal/index.tsx
@@ -1,0 +1,153 @@
+import { forwardRef, useState } from "react";
+import { FinalApproveModalFormValues, finalApproveModalFormSchema } from "../LargeGrantFinalApproveModal/schema";
+import { LargeMilestoneWithRelatedData } from "../LargeMilestoneCompleted";
+import { FormProvider } from "react-hook-form";
+import { Toaster } from "react-hot-toast";
+import { Button } from "~~/components/pg-ens/Button";
+import { FormTextarea } from "~~/components/pg-ens/form-fields/FormTextarea";
+import { Address } from "~~/components/scaffold-eth";
+import { useFormMethods } from "~~/hooks/pg-ens/useFormMethods";
+import { useLargeMilestoneReview } from "~~/hooks/pg-ens/useLargeMilestoneReview";
+import { useScaffoldWriteContract } from "~~/hooks/scaffold-eth";
+import { notification } from "~~/utils/scaffold-eth";
+
+const LOADING_STATUS_MAP = {
+  Approving: "Approving milestone",
+  Completing: "Completing milestone",
+  Empty: "",
+} as const;
+
+const WAITING_FOR_SIGNATURE_POSTFIX = "waiting for signature";
+
+type LoadingStatus = (typeof LOADING_STATUS_MAP)[keyof typeof LOADING_STATUS_MAP];
+
+const getLoadingStatusText = ({ status, isWaiting }: { status: LoadingStatus; isWaiting: boolean }) => {
+  if (status === LOADING_STATUS_MAP.Empty) {
+    return status;
+  }
+
+  if (isWaiting) {
+    return `${status}, ${WAITING_FOR_SIGNATURE_POSTFIX}...`;
+  }
+
+  return `${status}...`;
+};
+
+export const LargeMilestoneApprovalModal = forwardRef<
+  HTMLDialogElement,
+  {
+    milestone: LargeMilestoneWithRelatedData;
+  }
+>(({ milestone }, ref) => {
+  const { reviewMilestone, isSigning } = useLargeMilestoneReview(milestone.id);
+  const [loadingStatus, setLoadingStatus] = useState<LoadingStatus>(LOADING_STATUS_MAP.Empty);
+
+  const { getCommonOptions, formMethods } = useFormMethods<FinalApproveModalFormValues>({
+    schema: finalApproveModalFormSchema,
+  });
+
+  const { handleSubmit } = formMethods;
+
+  const { writeContractAsync, isPending: isWriteContractPending } = useScaffoldWriteContract("LargeGrant");
+
+  const handleApproveMilestone = async () => {
+    try {
+      let txHash;
+
+      if (milestone.status === "verified") {
+        setLoadingStatus(LOADING_STATUS_MAP.Completing);
+        txHash = await writeContractAsync({
+          functionName: "completeMilestone",
+          args: [
+            BigInt(milestone.stage.grant.id),
+            milestone.stage.stageNumber,
+            milestone.milestoneNumber,
+            milestone.description,
+            milestone.completionProof || "",
+          ],
+        });
+      } else {
+        setLoadingStatus(LOADING_STATUS_MAP.Approving);
+        txHash = await writeContractAsync({
+          functionName: "approveMilestone",
+          args: [BigInt(milestone.stage.grant.id), milestone.stage.stageNumber, milestone.milestoneNumber],
+        });
+      }
+
+      return txHash;
+    } catch (e) {
+      console.error("Error sending milestone transaction", e);
+    }
+  };
+
+  const onSubmit = async (fieldValues: FinalApproveModalFormValues) => {
+    const txHash = await handleApproveMilestone();
+    if (!txHash) {
+      setLoadingStatus(LOADING_STATUS_MAP.Empty);
+      return notification.error("Error approving milestone");
+    }
+    if (milestone.status === "verified") {
+      setLoadingStatus(LOADING_STATUS_MAP.Completing);
+      await reviewMilestone({ status: "paid", ...fieldValues, txHash });
+      setLoadingStatus(LOADING_STATUS_MAP.Empty);
+    }
+    if (milestone.status === "completed") {
+      setLoadingStatus(LOADING_STATUS_MAP.Approving);
+      await reviewMilestone({ status: "verified", ...fieldValues, txHash });
+      setLoadingStatus(LOADING_STATUS_MAP.Empty);
+    }
+  };
+
+  const loadingStatusText = getLoadingStatusText({
+    status: loadingStatus,
+    isWaiting: isSigning || isWriteContractPending,
+  });
+
+  if (milestone.status !== "completed" && milestone.status !== "verified") {
+    return notification.error("Milestone is not in a valid state for approval.");
+  }
+
+  return (
+    <dialog id="action_modal" className="modal" ref={ref}>
+      <div className="modal-box flex flex-col space-y-3">
+        <form method="dialog" className="bg-secondary -mx-6 -mt-6 px-6 py-4 flex items-center justify-between">
+          <div className="flex justify-between items-center">
+            <p className="font-bold text-xl m-0">
+              Verify Milestone {milestone.milestoneNumber} - Stage {milestone.stage.stageNumber} for{" "}
+              {milestone.stage.grant.title}
+            </p>
+          </div>
+          <button className="btn btn-sm btn-circle btn-ghost text-xl h-auto">✕</button>
+        </form>
+        <FormProvider {...formMethods}>
+          {milestone.status === "verified" && (
+            <>
+              <div className="font-bold">Pre-approved by:</div>
+              <div className="flex items-center gap-2">
+                <Address address={milestone.verifiedBy as `0x${string}`} />
+              </div>
+              <div className="divider" />
+            </>
+          )}
+          <form onSubmit={handleSubmit(onSubmit)} className="w-full flex flex-col gap-1">
+            {milestone.status === "verified" && (
+              <FormTextarea label="Note (visible to grantee)" {...getCommonOptions("statusNote")} />
+            )}
+            {loadingStatusText && (
+              <div className="text-xl flex justify-center items-center gap-2 my-2">
+                <span className="loading loading-spinner" />
+                {loadingStatusText}
+              </div>
+            )}
+            <Button variant="green" type="submit" className="!px-4 self-center" disabled={Boolean(loadingStatus)}>
+              <span>{milestone.status === "verified" ? "Final Approve" : "Approve"}</span>
+            </Button>
+          </form>
+        </FormProvider>
+      </div>
+      <Toaster />
+    </dialog>
+  );
+});
+
+LargeMilestoneApprovalModal.displayName = "LargeMilestoneApprovalModal";

--- a/packages/nextjs/app/admin/_components/LargeMilestoneApprovalModal/index.tsx
+++ b/packages/nextjs/app/admin/_components/LargeMilestoneApprovalModal/index.tsx
@@ -104,7 +104,18 @@ export const LargeMilestoneApprovalModal = forwardRef<
   });
 
   if (milestone.status !== "completed" && milestone.status !== "verified") {
-    return notification.error("Milestone is not in a valid state for approval.");
+    return (
+      <dialog id="action_modal" className="modal" ref={ref}>
+        <div className="modal-box flex flex-col space-y-3">
+          <form method="dialog" className="bg-secondary -mx-6 -mt-6 px-6 py-4 flex items-center justify-between">
+            <div className="flex justify-between items-center">
+              <p className="font-bold text-xl m-0">Milestone is not in a valid state for approval.</p>
+            </div>
+            <button className="btn btn-sm btn-circle btn-ghost text-xl h-auto">✕</button>
+          </form>
+        </div>
+      </dialog>
+    );
   }
 
   return (

--- a/packages/nextjs/app/admin/_components/LargeMilestoneCompleted.tsx
+++ b/packages/nextjs/app/admin/_components/LargeMilestoneCompleted.tsx
@@ -48,7 +48,8 @@ export const LargeMilestoneCompleted = ({ milestone }: { milestone: LargeMilesto
   return (
     <div className="card bg-white text-primary-content w-full max-w-lg shadow-center">
       <div className="px-5 py-3 flex justify-between items-center w-full">
-        <div className="font-bold text-xl">
+        <div className="font-bold text-xl flex items-center">
+          <div className="rounded-full bg-primary h-3.5 w-3.5 mr-2" />
           {milestone.stage.grant.title} - Stage {latestStage.stageNumber}
         </div>
         <div>{milestone.completedAt?.toLocaleDateString()}</div>

--- a/packages/nextjs/app/admin/_components/LargeMilestoneCompleted.tsx
+++ b/packages/nextjs/app/admin/_components/LargeMilestoneCompleted.tsx
@@ -136,7 +136,11 @@ export const LargeMilestoneCompleted = ({ milestone }: { milestone: LargeMilesto
         )}
       </div>
 
-      <LargeMilestoneApprovalModal ref={approvalModalRef} milestone={milestone} />
+      <LargeMilestoneApprovalModal
+        ref={approvalModalRef}
+        milestone={milestone}
+        closeModal={() => approvalModalRef.current?.close()}
+      />
       <LargeMilestoneRejectModal ref={rejectModalRef} milestone={milestone} />
       <MilestonePrivateNoteModal
         ref={privateNoteModalRef}

--- a/packages/nextjs/app/admin/_components/LargeMilestoneCompleted.tsx
+++ b/packages/nextjs/app/admin/_components/LargeMilestoneCompleted.tsx
@@ -11,6 +11,7 @@ import { Button } from "~~/components/pg-ens/Button";
 import { FormErrorMessage } from "~~/components/pg-ens/form-fields/FormErrorMessage";
 import { Address } from "~~/components/scaffold-eth";
 import { getCompletedOrVerifiedMilestones } from "~~/services/database/repositories/large-milestones";
+import { getFormattedDateWithDay } from "~~/utils/getFormattedDate";
 import { multilineStringToTsx } from "~~/utils/multiline-string-to-tsx";
 
 function isElementClamped(element: HTMLElement | null) {
@@ -52,7 +53,7 @@ export const LargeMilestoneCompleted = ({ milestone }: { milestone: LargeMilesto
           <div className="rounded-full bg-primary h-3.5 w-3.5 min-w-3.5 mr-2" />
           {milestone.stage.grant.title} - Stage {latestStage.stageNumber}
         </div>
-        <div>{milestone.completedAt?.toLocaleDateString()}</div>
+        <div>{milestone.completedAt && getFormattedDateWithDay(milestone.completedAt)}</div>
       </div>
       <div className="px-5 py-8 bg-gray-100">
         <div className="flex justify-between">
@@ -67,7 +68,7 @@ export const LargeMilestoneCompleted = ({ milestone }: { milestone: LargeMilesto
           View grant page <ArrowTopRightOnSquareIcon className="w-5 h-5" />
         </Link>
         <div className="mt-6 flex flex-col lg:flex-row gap-1">
-          <span className="font-bold">Deadline:</span> {milestone.proposedCompletionDate.toLocaleDateString()}
+          <span className="font-bold">Deadline:</span> {getFormattedDateWithDay(milestone.proposedCompletionDate)}
         </div>
       </div>
 

--- a/packages/nextjs/app/admin/_components/LargeMilestoneCompleted.tsx
+++ b/packages/nextjs/app/admin/_components/LargeMilestoneCompleted.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { LargeMilestoneApprovalModal } from "./LargeMilestoneApprovalModal";
+import { LargeMilestoneRejectModal } from "./LargeMilestoneRejectModal";
+import { MilestonePrivateNoteModal } from "./MilestonePrivateNoteModal";
+import { useAccount } from "wagmi";
+import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/outline";
+import { Button } from "~~/components/pg-ens/Button";
+import { FormErrorMessage } from "~~/components/pg-ens/form-fields/FormErrorMessage";
+import { Address } from "~~/components/scaffold-eth";
+import { getCompledOrVerifiedMilestones } from "~~/services/database/repositories/large-milestones";
+import { multilineStringToTsx } from "~~/utils/multiline-string-to-tsx";
+
+function isElementClamped(element: HTMLElement | null) {
+  if (!element) return false;
+  return element.scrollHeight > element.clientHeight;
+}
+
+export type LargeMilestoneWithRelatedData = Awaited<ReturnType<typeof getCompledOrVerifiedMilestones>>[0];
+
+export const LargeMilestoneCompleted = ({ milestone }: { milestone: LargeMilestoneWithRelatedData }) => {
+  const milesonesRef = useRef<HTMLDivElement>(null);
+  const [isDefaultExpanded, setIsDefaultExpanded] = useState(true);
+  const [isExpandedByClick, setIsExpandedByClick] = useState(false);
+  const [canVote, setCanVote] = useState(true);
+  const { address } = useAccount();
+
+  const privateNoteModalRef = useRef<HTMLDialogElement>(null);
+  const approvalModalRef = useRef<HTMLDialogElement>(null);
+  const rejectModalRef = useRef<HTMLDialogElement>(null);
+
+  const latestStage = milestone.stage;
+  const privateNotes = milestone.privateNotes;
+
+  const isFinalApproveAvailable = milestone.status === "verified";
+
+  useEffect(() => {
+    // waits for render to calculate
+    setIsDefaultExpanded(!isElementClamped(milesonesRef.current));
+  }, []);
+
+  useEffect(() => {
+    setCanVote(milestone.verifiedBy !== address);
+  }, [milestone.verifiedBy, address]);
+
+  return (
+    <div className="card bg-white text-primary-content w-full max-w-lg shadow-center">
+      <div className="px-5 py-3 flex justify-between items-center w-full">
+        <div className="font-bold text-xl">
+          {milestone.stage.grant.title} - Stage {latestStage.stageNumber}
+        </div>
+        <div>{milestone.completedAt?.toLocaleDateString()}</div>
+      </div>
+      <div className="px-5 py-8 bg-gray-100">
+        <div className="flex justify-between">
+          <h2 className="text-2xl font-bold mb-0">Milestone {milestone.milestoneNumber}</h2>
+          <div className="bg-white rounded-lg p-1">{milestone.amount.toLocaleString()} USDC</div>
+        </div>
+        <Link
+          href={`/large-grants/${milestone.stage.grant.id}`}
+          className="text-gray-500 underline flex items-center gap-1 mr-2"
+          target="_blank"
+        >
+          View grant page <ArrowTopRightOnSquareIcon className="w-5 h-5" />
+        </Link>
+        <div className="mt-6 flex flex-col lg:flex-row gap-1">
+          <span className="font-bold">Deadline:</span> {milestone.proposedCompletionDate.toLocaleDateString()}
+        </div>
+      </div>
+
+      <div className="p-5">
+        <div className="mt-2">
+          <div className={isExpandedByClick ? "" : "line-clamp-2"} ref={milesonesRef}>
+            <div>
+              Description:
+              {multilineStringToTsx(milestone.description)}
+            </div>
+            {milestone.completionProof && (
+              <div>
+                Completion Proof:
+                {multilineStringToTsx(milestone.completionProof)}
+              </div>
+            )}
+          </div>
+          {!isDefaultExpanded && !isExpandedByClick && (
+            <button className="bg-transparent font-semibold underline" onClick={() => setIsExpandedByClick(true)}>
+              Read more
+            </button>
+          )}
+        </div>
+
+        <div className="flex flex-col lg:flex-row-reverse lg:items-start justify-between gap-3 mt-4">
+          <div className="flex flex-col lg:flex-row lg:items-start gap-3">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => privateNoteModalRef && privateNoteModalRef.current?.showModal()}
+            >
+              Set private note
+            </Button>
+
+            <div className="flex flex-col gap-1">
+              <Button
+                variant={`green${isFinalApproveAvailable ? "" : "-secondary"}`}
+                size="sm"
+                onClick={() => approvalModalRef && approvalModalRef.current?.showModal()}
+                disabled={!canVote}
+              >
+                {isFinalApproveAvailable ? "Final Approve" : "Vote for approval"}
+              </Button>
+              {!canVote && <FormErrorMessage error="Already voted" className="text-center" />}
+            </div>
+          </div>
+          <Button
+            variant="red-secondary"
+            size="sm"
+            onClick={() => rejectModalRef && rejectModalRef.current?.showModal()}
+          >
+            Reject
+          </Button>
+        </div>
+
+        {privateNotes?.length > 0 && (
+          <div className="mt-5 pt-3 border-t border-gray-200">
+            {privateNotes.map(privateNote => (
+              <div key={privateNote.id} className="mt-1 first:mt-0 text-gray-400">
+                <div className="flex gap-1">
+                  <Address address={privateNote.authorAddress as `0x${string}`} /> :
+                </div>
+                <div className="ml-[30px]">{multilineStringToTsx(privateNote.note)}</div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <LargeMilestoneApprovalModal ref={approvalModalRef} milestone={milestone} />
+      <LargeMilestoneRejectModal ref={rejectModalRef} milestone={milestone} />
+      <MilestonePrivateNoteModal
+        ref={privateNoteModalRef}
+        milestone={milestone}
+        closeModal={() => privateNoteModalRef.current?.close()}
+      />
+    </div>
+  );
+};

--- a/packages/nextjs/app/admin/_components/LargeMilestoneCompleted.tsx
+++ b/packages/nextjs/app/admin/_components/LargeMilestoneCompleted.tsx
@@ -10,7 +10,7 @@ import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/outline";
 import { Button } from "~~/components/pg-ens/Button";
 import { FormErrorMessage } from "~~/components/pg-ens/form-fields/FormErrorMessage";
 import { Address } from "~~/components/scaffold-eth";
-import { getCompledOrVerifiedMilestones } from "~~/services/database/repositories/large-milestones";
+import { getCompletedOrVerifiedMilestones } from "~~/services/database/repositories/large-milestones";
 import { multilineStringToTsx } from "~~/utils/multiline-string-to-tsx";
 
 function isElementClamped(element: HTMLElement | null) {
@@ -18,7 +18,7 @@ function isElementClamped(element: HTMLElement | null) {
   return element.scrollHeight > element.clientHeight;
 }
 
-export type LargeMilestoneWithRelatedData = Awaited<ReturnType<typeof getCompledOrVerifiedMilestones>>[0];
+export type LargeMilestoneWithRelatedData = Awaited<ReturnType<typeof getCompletedOrVerifiedMilestones>>[0];
 
 export const LargeMilestoneCompleted = ({ milestone }: { milestone: LargeMilestoneWithRelatedData }) => {
   const milesonesRef = useRef<HTMLDivElement>(null);

--- a/packages/nextjs/app/admin/_components/LargeMilestoneCompleted.tsx
+++ b/packages/nextjs/app/admin/_components/LargeMilestoneCompleted.tsx
@@ -49,7 +49,7 @@ export const LargeMilestoneCompleted = ({ milestone }: { milestone: LargeMilesto
     <div className="card bg-white text-primary-content w-full max-w-lg shadow-center">
       <div className="px-5 py-3 flex justify-between items-center w-full">
         <div className="font-bold text-xl flex items-center">
-          <div className="rounded-full bg-primary h-3.5 w-3.5 mr-2" />
+          <div className="rounded-full bg-primary h-3.5 w-3.5 min-w-3.5 mr-2" />
           {milestone.stage.grant.title} - Stage {latestStage.stageNumber}
         </div>
         <div>{milestone.completedAt?.toLocaleDateString()}</div>

--- a/packages/nextjs/app/admin/_components/LargeMilestoneCompleted.tsx
+++ b/packages/nextjs/app/admin/_components/LargeMilestoneCompleted.tsx
@@ -55,21 +55,30 @@ export const LargeMilestoneCompleted = ({ milestone }: { milestone: LargeMilesto
         </div>
         <div>{milestone.completedAt && getFormattedDateWithDay(milestone.completedAt)}</div>
       </div>
-      <div className="px-5 py-8 bg-gray-100">
+      <div className={`px-5 pt-5 bg-gray-100 ${isFinalApproveAvailable ? "pb-2" : "pb-5"}`}>
         <div className="flex justify-between">
           <h2 className="text-2xl font-bold mb-0">Milestone {milestone.milestoneNumber}</h2>
           <div className="bg-white rounded-lg p-1">{milestone.amount.toLocaleString()} USDC</div>
         </div>
-        <Link
-          href={`/large-grants/${milestone.stage.grant.id}`}
-          className="text-gray-500 underline flex items-center gap-1 mr-2"
-          target="_blank"
-        >
-          View grant page <ArrowTopRightOnSquareIcon className="w-5 h-5" />
-        </Link>
-        <div className="mt-6 flex flex-col lg:flex-row gap-1">
-          <span className="font-bold">Deadline:</span> {getFormattedDateWithDay(milestone.proposedCompletionDate)}
+        <div className="flex justify-between">
+          <Link
+            href={`/large-grants/${milestone.stage.grant.id}`}
+            className="text-gray-500 underline flex items-center gap-1 mr-2"
+            target="_blank"
+          >
+            View grant page <ArrowTopRightOnSquareIcon className="w-5 h-5" />
+          </Link>
+          <div className="font-semibold">
+            <span>Deadline:</span> {getFormattedDateWithDay(milestone.proposedCompletionDate)}
+          </div>
         </div>
+        {isFinalApproveAvailable && (
+          <div className="flex gap-1 justify-end">
+            <div className="tooltip" data-tip={`Pre-approved by ${milestone.verifiedBy}`}>
+              <div>👍</div>
+            </div>
+          </div>
+        )}
       </div>
 
       <div className="p-5">
@@ -119,11 +128,7 @@ export const LargeMilestoneCompleted = ({ milestone }: { milestone: LargeMilesto
               {!canVote && <FormErrorMessage error="Already voted" className="text-center" />}
             </div>
           </div>
-          <Button
-            variant="red-secondary"
-            size="sm"
-            onClick={() => rejectModalRef && rejectModalRef.current?.showModal()}
-          >
+          <Button variant="red" size="sm" onClick={() => rejectModalRef && rejectModalRef.current?.showModal()}>
             Reject
           </Button>
         </div>

--- a/packages/nextjs/app/admin/_components/LargeMilestoneCompleted.tsx
+++ b/packages/nextjs/app/admin/_components/LargeMilestoneCompleted.tsx
@@ -72,15 +72,19 @@ export const LargeMilestoneCompleted = ({ milestone }: { milestone: LargeMilesto
       </div>
 
       <div className="p-5">
-        <div className="mt-2">
+        <div>
           <div className={isExpandedByClick ? "" : "line-clamp-2"} ref={milesonesRef}>
             <div>
-              Description:
+              <span className="font-semibold">Description:</span>
               {multilineStringToTsx(milestone.description)}
             </div>
+            <div className="mt-2">
+              <span className="font-semibold">Proposed Deliverables:</span>
+              {multilineStringToTsx(milestone.proposedDeliverables)}
+            </div>
             {milestone.completionProof && (
-              <div>
-                Completion Proof:
+              <div className="mt-2">
+                <span className="font-semibold">Completion Proof:</span>
                 {multilineStringToTsx(milestone.completionProof)}
               </div>
             )}

--- a/packages/nextjs/app/admin/_components/LargeMilestoneRejectModal/index.tsx
+++ b/packages/nextjs/app/admin/_components/LargeMilestoneRejectModal/index.tsx
@@ -1,0 +1,61 @@
+import { forwardRef } from "react";
+import { LargeMilestoneWithRelatedData } from "../LargeMilestoneCompleted";
+import { RejectModalFormValues, rejectModalFormSchema } from "./schema";
+import { FormProvider } from "react-hook-form";
+import { ExclamationTriangleIcon } from "@heroicons/react/24/solid";
+import { Button } from "~~/components/pg-ens/Button";
+import { FormTextarea } from "~~/components/pg-ens/form-fields/FormTextarea";
+import { useFormMethods } from "~~/hooks/pg-ens/useFormMethods";
+import { useLargeMilestoneReview } from "~~/hooks/pg-ens/useLargeMilestoneReview";
+
+interface RejectModalProps {
+  milestone: LargeMilestoneWithRelatedData;
+}
+
+export const LargeMilestoneRejectModal = forwardRef<HTMLDialogElement, RejectModalProps>(({ milestone }, ref) => {
+  const { reviewMilestone, isSigning, isPostingMilestoneReview } = useLargeMilestoneReview(milestone.id);
+
+  const { formMethods, getCommonOptions } = useFormMethods<RejectModalFormValues>({ schema: rejectModalFormSchema });
+  const { handleSubmit } = formMethods;
+
+  const onSubmit = async (fieldValues: RejectModalFormValues) => {
+    await reviewMilestone({ status: "rejected", ...fieldValues });
+  };
+
+  return (
+    <dialog id="action_modal" className="modal" ref={ref}>
+      <div className="modal-box flex flex-col space-y-3">
+        <form method="dialog" className="bg-secondary -mx-6 -mt-6 px-6 py-4 flex items-center justify-between">
+          <div className="flex justify-between items-center">
+            <p className="font-bold text-xl m-0">
+              Reject milestone {milestone.milestoneNumber} - {milestone.stage.stageNumber} for{" "}
+              {milestone.stage.grant.title}
+            </p>
+          </div>
+          {/* if there is a button in form, it will close the modal */}
+          <button className="btn btn-sm btn-circle btn-ghost text-xl h-auto">✕</button>
+        </form>
+        <FormProvider {...formMethods}>
+          <div className="flex items-center gap-1">
+            <ExclamationTriangleIcon className="w-6 h-6 text-primary-orange" />
+            <span>Clicking Reject will change the status of this milestone to Rejected</span>
+          </div>
+          <form onSubmit={handleSubmit(onSubmit)} className="w-full flex flex-col space-y-1">
+            <FormTextarea label="Note (visible to grantee)" {...getCommonOptions("statusNote")} />
+            <Button
+              variant="red"
+              type="submit"
+              disabled={isPostingMilestoneReview || isSigning}
+              className="self-center"
+            >
+              {(isPostingMilestoneReview || isSigning) && <span className="loading loading-spinner"></span>}
+              Reject
+            </Button>
+          </form>
+        </FormProvider>
+      </div>
+    </dialog>
+  );
+});
+
+LargeMilestoneRejectModal.displayName = "LargeMilestoneRejectModal";

--- a/packages/nextjs/app/admin/_components/LargeMilestoneRejectModal/schema.tsx
+++ b/packages/nextjs/app/admin/_components/LargeMilestoneRejectModal/schema.tsx
@@ -1,0 +1,8 @@
+import * as z from "zod";
+import { DEFAULT_TEXTAREA_MAX_LENGTH } from "~~/utils/forms";
+
+export const rejectModalFormSchema = z.object({
+  statusNote: z.string().max(DEFAULT_TEXTAREA_MAX_LENGTH).optional(),
+});
+
+export type RejectModalFormValues = z.infer<typeof rejectModalFormSchema>;

--- a/packages/nextjs/app/admin/_components/LargeRejectModal/index.tsx
+++ b/packages/nextjs/app/admin/_components/LargeRejectModal/index.tsx
@@ -1,56 +1,133 @@
 import { forwardRef } from "react";
+import { useRouter } from "next/navigation";
 import { RejectModalFormValues, rejectModalFormSchema } from "./schema";
+import { useMutation } from "@tanstack/react-query";
 import { FormProvider } from "react-hook-form";
+import { Toaster } from "react-hot-toast";
+import { useSignTypedData } from "wagmi";
 import { ExclamationTriangleIcon } from "@heroicons/react/24/solid";
+import { RejectVoteReqBody } from "~~/app/api/large-stages/[stageId]/reject-vote/route";
 import { Button } from "~~/components/pg-ens/Button";
 import { FormTextarea } from "~~/components/pg-ens/form-fields/FormTextarea";
+import { Address } from "~~/components/scaffold-eth";
 import { useFormMethods } from "~~/hooks/pg-ens/useFormMethods";
-import { useLargeStageReview } from "~~/hooks/pg-ens/useLargeStageReview";
-import { LargeStage } from "~~/services/database/repositories/large-stages";
+import { LargeGrantWithStagesAndPrivateNotes } from "~~/types/utils";
+import { MINIMAL_VOTES_FOR_FINAL_APPROVAL } from "~~/utils/approval-votes";
+import { EIP_712_DOMAIN, EIP_712_TYPES__LARGE_STAGE_REJECT_VOTE } from "~~/utils/eip712";
+import { postMutationFetcher } from "~~/utils/react-query";
+import { getParsedError, notification } from "~~/utils/scaffold-eth";
 
 interface RejectModalProps {
-  stage: LargeStage;
+  stage: LargeGrantWithStagesAndPrivateNotes["stages"][number];
   grantName: string;
+  closeModal: () => void;
 }
 
-export const LargeRejectModal = forwardRef<HTMLDialogElement, RejectModalProps>(({ stage, grantName }, ref) => {
-  const { reviewStage, isSigning, isPostingStageReview } = useLargeStageReview(stage.id);
+export const LargeRejectModal = forwardRef<HTMLDialogElement, RejectModalProps>(
+  ({ stage, grantName, closeModal }, ref) => {
+    const { formMethods, getCommonOptions } = useFormMethods<RejectModalFormValues>({ schema: rejectModalFormSchema });
+    const { handleSubmit } = formMethods;
+    const { rejectVotes } = stage;
+    const finalReject = rejectVotes.length + 1 === MINIMAL_VOTES_FOR_FINAL_APPROVAL;
 
-  const { formMethods, getCommonOptions } = useFormMethods<RejectModalFormValues>({ schema: rejectModalFormSchema });
-  const { handleSubmit } = formMethods;
+    const router = useRouter();
 
-  const onSubmit = async (fieldValues: RejectModalFormValues) => {
-    await reviewStage({ status: "rejected", ...fieldValues });
-  };
+    const { signTypedDataAsync, isPending: isSigning } = useSignTypedData();
 
-  return (
-    <dialog id="action_modal" className="modal" ref={ref}>
-      <div className="modal-box flex flex-col space-y-3">
-        <form method="dialog" className="bg-secondary -mx-6 -mt-6 px-6 py-4 flex items-center justify-between">
-          <div className="flex justify-between items-center">
-            <p className="font-bold text-xl m-0">
-              Reject stage {stage.stageNumber} for {grantName}
-            </p>
-          </div>
-          {/* if there is a button in form, it will close the modal */}
-          <button className="btn btn-sm btn-circle btn-ghost text-xl h-auto">✕</button>
-        </form>
-        <FormProvider {...formMethods}>
-          <div className="flex items-center gap-1">
-            <ExclamationTriangleIcon className="w-6 h-6 text-primary-orange" />
-            <span>Clicking Reject will change the status of this grant to Rejected</span>
-          </div>
-          <form onSubmit={handleSubmit(onSubmit)} className="w-full flex flex-col space-y-1">
-            <FormTextarea label="Note (visible to grantee)" {...getCommonOptions("statusNote")} />
-            <Button variant="red" type="submit" disabled={isPostingStageReview || isSigning} className="self-center">
-              {(isPostingStageReview || isSigning) && <span className="loading loading-spinner"></span>}
-              Reject
-            </Button>
+    const { mutateAsync: postRejectVote, isPending: isPostingRejectVote } = useMutation({
+      mutationFn: (rejectVoteBody: RejectVoteReqBody) =>
+        postMutationFetcher(`/api/large-stages/${stage.id}/reject-vote`, { body: rejectVoteBody }),
+    });
+
+    const onSubmit = async (fieldValues: RejectModalFormValues) => {
+      try {
+        const signature = await signTypedDataAsync({
+          domain: EIP_712_DOMAIN,
+          types: EIP_712_TYPES__LARGE_STAGE_REJECT_VOTE,
+          primaryType: "Message",
+          message: {
+            stageId: String(stage.id),
+            statusNote: fieldValues.statusNote || "",
+          },
+        });
+
+        await postRejectVote({ signature, statusNote: fieldValues.statusNote || "" });
+        closeModal();
+        router.refresh();
+      } catch (error) {
+        const errorMessage = getParsedError(error);
+        notification.error(errorMessage);
+      }
+    };
+
+    return (
+      <dialog id="action_modal" className="modal" ref={ref}>
+        <div className="modal-box flex flex-col space-y-3">
+          <form method="dialog" className="bg-secondary -mx-6 -mt-6 px-6 py-4 flex items-center justify-between">
+            <div className="flex justify-between items-center">
+              <p className="font-bold text-xl m-0">
+                Reject {stage.stageNumber > 1 ? `Stage ${stage.stageNumber} of ${grantName}` : grantName}
+              </p>
+            </div>
+            {/* if there is a button in form, it will close the modal */}
+            <button className="btn btn-sm btn-circle btn-ghost text-xl h-auto">✕</button>
           </form>
-        </FormProvider>
-      </div>
-    </dialog>
-  );
-});
+          <FormProvider {...formMethods}>
+            {rejectVotes.length > 0 && (
+              <>
+                <div className="font-bold">Pre-rejected by:</div>
+
+                {rejectVotes.map(rejectVote => (
+                  <div key={rejectVote.id} className="flex items-center gap-2">
+                    <Address address={rejectVote.authorAddress as `0x${string}`} />
+                  </div>
+                ))}
+                <div className="divider" />
+              </>
+            )}
+
+            <form onSubmit={handleSubmit(onSubmit)} className="w-full flex flex-col space-y-1">
+              {finalReject ? (
+                <>
+                  <div className="flex items-center gap-1 mb-4">
+                    <ExclamationTriangleIcon className="w-6 h-6 text-primary-orange" />
+                    <span>Clicking Reject will change the status of this grant to Rejected</span>
+                  </div>
+                  <FormTextarea label="Note (visible to grantee)" {...getCommonOptions("statusNote")} />
+                </>
+              ) : (
+                <div className="mb-4 mt-4">
+                  Are you sure you want to vote for the rejection of this {stage.stageNumber > 1 ? "stage" : "grant"}?
+                </div>
+              )}
+              <div className="flex justify-between">
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  disabled={isPostingRejectVote || isSigning}
+                  className="self-center"
+                  type="button"
+                  onClick={closeModal}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  variant={finalReject ? "red" : "red-secondary"}
+                  type="submit"
+                  disabled={isPostingRejectVote || isSigning}
+                  className="self-center"
+                >
+                  {(isPostingRejectVote || isSigning) && <span className="loading loading-spinner"></span>}
+                  {finalReject ? "Reject" : "Vote for Rejection"}
+                </Button>
+              </div>
+            </form>
+          </FormProvider>
+        </div>
+        <Toaster />
+      </dialog>
+    );
+  },
+);
 
 LargeRejectModal.displayName = "LargeRejectModal";

--- a/packages/nextjs/app/admin/_components/LargeRejectModal/index.tsx
+++ b/packages/nextjs/app/admin/_components/LargeRejectModal/index.tsx
@@ -1,0 +1,56 @@
+import { forwardRef } from "react";
+import { RejectModalFormValues, rejectModalFormSchema } from "./schema";
+import { FormProvider } from "react-hook-form";
+import { ExclamationTriangleIcon } from "@heroicons/react/24/solid";
+import { Button } from "~~/components/pg-ens/Button";
+import { FormTextarea } from "~~/components/pg-ens/form-fields/FormTextarea";
+import { useFormMethods } from "~~/hooks/pg-ens/useFormMethods";
+import { useLargeStageReview } from "~~/hooks/pg-ens/useLargeStageReview";
+import { LargeStage } from "~~/services/database/repositories/large-stages";
+
+interface RejectModalProps {
+  stage: LargeStage;
+  grantName: string;
+}
+
+export const LargeRejectModal = forwardRef<HTMLDialogElement, RejectModalProps>(({ stage, grantName }, ref) => {
+  const { reviewStage, isSigning, isPostingStageReview } = useLargeStageReview(stage.id);
+
+  const { formMethods, getCommonOptions } = useFormMethods<RejectModalFormValues>({ schema: rejectModalFormSchema });
+  const { handleSubmit } = formMethods;
+
+  const onSubmit = async (fieldValues: RejectModalFormValues) => {
+    await reviewStage({ status: "rejected", ...fieldValues });
+  };
+
+  return (
+    <dialog id="action_modal" className="modal" ref={ref}>
+      <div className="modal-box flex flex-col space-y-3">
+        <form method="dialog" className="bg-secondary -mx-6 -mt-6 px-6 py-4 flex items-center justify-between">
+          <div className="flex justify-between items-center">
+            <p className="font-bold text-xl m-0">
+              Reject stage {stage.stageNumber} for {grantName}
+            </p>
+          </div>
+          {/* if there is a button in form, it will close the modal */}
+          <button className="btn btn-sm btn-circle btn-ghost text-xl h-auto">✕</button>
+        </form>
+        <FormProvider {...formMethods}>
+          <div className="flex items-center gap-1">
+            <ExclamationTriangleIcon className="w-6 h-6 text-primary-orange" />
+            <span>Clicking Reject will change the status of this grant to Rejected</span>
+          </div>
+          <form onSubmit={handleSubmit(onSubmit)} className="w-full flex flex-col space-y-1">
+            <FormTextarea label="Note (visible to grantee)" {...getCommonOptions("statusNote")} />
+            <Button variant="red" type="submit" disabled={isPostingStageReview || isSigning} className="self-center">
+              {(isPostingStageReview || isSigning) && <span className="loading loading-spinner"></span>}
+              Reject
+            </Button>
+          </form>
+        </FormProvider>
+      </div>
+    </dialog>
+  );
+});
+
+LargeRejectModal.displayName = "LargeRejectModal";

--- a/packages/nextjs/app/admin/_components/LargeRejectModal/schema.tsx
+++ b/packages/nextjs/app/admin/_components/LargeRejectModal/schema.tsx
@@ -1,0 +1,8 @@
+import * as z from "zod";
+import { DEFAULT_TEXTAREA_MAX_LENGTH } from "~~/utils/forms";
+
+export const rejectModalFormSchema = z.object({
+  statusNote: z.string().max(DEFAULT_TEXTAREA_MAX_LENGTH).optional(),
+});
+
+export type RejectModalFormValues = z.infer<typeof rejectModalFormSchema>;

--- a/packages/nextjs/app/admin/_components/Proposal.tsx
+++ b/packages/nextjs/app/admin/_components/Proposal.tsx
@@ -58,7 +58,7 @@ export const Proposal = ({ proposal, userSubmissionsAmount, isGrant }: ProposalP
     <div className="card bg-white text-primary-content w-full max-w-lg shadow-center">
       <div className="px-5 py-3 flex justify-between items-center w-full">
         <div className="font-bold text-xl flex items-center">
-          <div className="rounded-full bg-medium-purple h-3.5 w-3.5 mr-2" />
+          <div className="rounded-full bg-medium-purple h-3.5 w-3.5 min-w-3.5 mr-2" />
           Stage {latestStage.stageNumber}
         </div>
         <div>{getFormattedDate(latestStage.submitedAt as Date)}</div>

--- a/packages/nextjs/app/admin/_components/Proposal.tsx
+++ b/packages/nextjs/app/admin/_components/Proposal.tsx
@@ -74,17 +74,21 @@ export const Proposal = ({ proposal, userSubmissionsAmount, isGrant }: ProposalP
         </Link>
         <div className="mt-6 flex flex-col lg:flex-row gap-1">
           <Address address={proposal.builderAddress} />
-          <span className="hidden lg:inline">·</span>
-          <Link
-            href={`/builder-grants/${proposal.builderAddress}`}
-            className="text-gray-500 underline flex items-center gap-1"
-            target="_blank"
-          >
-            <span>
-              {userSubmissionsAmount} submission{userSubmissionsAmount === 1 ? "" : "s"}
-            </span>
-            <ArrowTopRightOnSquareIcon className="w-5 h-5" />
-          </Link>
+          {latestStage.stageNumber === 1 && (
+            <>
+              <span className="hidden lg:inline">·</span>
+              <Link
+                href={`/builder-grants/${proposal.builderAddress}`}
+                className="text-gray-500 underline flex items-center gap-1"
+                target="_blank"
+              >
+                <span>
+                  {userSubmissionsAmount} submission{userSubmissionsAmount === 1 ? "" : "s"}
+                </span>
+                <ArrowTopRightOnSquareIcon className="w-5 h-5" />
+              </Link>
+            </>
+          )}
         </div>
       </div>
 

--- a/packages/nextjs/app/admin/_components/Proposal.tsx
+++ b/packages/nextjs/app/admin/_components/Proposal.tsx
@@ -57,7 +57,10 @@ export const Proposal = ({ proposal, userSubmissionsAmount, isGrant }: ProposalP
   return (
     <div className="card bg-white text-primary-content w-full max-w-lg shadow-center">
       <div className="px-5 py-3 flex justify-between items-center w-full">
-        <div className="font-bold text-xl">Stage {latestStage.stageNumber}</div>
+        <div className="font-bold text-xl flex items-center">
+          <div className="rounded-full bg-medium-purple h-3.5 w-3.5 mr-2" />
+          Stage {latestStage.stageNumber}
+        </div>
         <div>{getFormattedDate(latestStage.submitedAt as Date)}</div>
       </div>
       <div className="px-5 py-8 bg-gray-100">

--- a/packages/nextjs/app/admin/_components/Proposal.tsx
+++ b/packages/nextjs/app/admin/_components/Proposal.tsx
@@ -139,7 +139,7 @@ export const Proposal = ({ proposal, userSubmissionsAmount, isGrant }: ProposalP
                 >
                   Vote for approval
                 </Button>
-                {!canVote && <FormErrorMessage error="Already voted" className="text-center" />}
+                {!canVote && <FormErrorMessage error="Voted" className="text-center" />}
               </div>
             )}
           </div>

--- a/packages/nextjs/app/admin/page.tsx
+++ b/packages/nextjs/app/admin/page.tsx
@@ -7,7 +7,7 @@ import { getServerSession } from "next-auth";
 import { SignInBtn } from "~~/components/pg-ens/SignInBtn";
 import { getAllGrantsWithStagesAndPrivateNotes } from "~~/services/database/repositories/grants";
 import { getAllLargeGrantsWithStagesAndPrivateNotes } from "~~/services/database/repositories/large-grants";
-import { getCompledOrVerifiedMilestones } from "~~/services/database/repositories/large-milestones";
+import { getCompletedOrVerifiedMilestones } from "~~/services/database/repositories/large-milestones";
 import { DiscriminatedGrantWithStagesAndPrivateNotes } from "~~/types/utils";
 import { authOptions } from "~~/utils/auth";
 
@@ -61,7 +61,7 @@ const Admin: NextPage = async () => {
     }
   });
 
-  const milestones = await getCompledOrVerifiedMilestones();
+  const milestones = await getCompletedOrVerifiedMilestones();
 
   return (
     <div className="flex flex-col flex-grow px-4 py-10 sm:py-20">

--- a/packages/nextjs/app/admin/page.tsx
+++ b/packages/nextjs/app/admin/page.tsx
@@ -1,9 +1,14 @@
 import { redirect } from "next/navigation";
-import { GrantWithStagesAndPrivateNotes, Proposal } from "./_components/Proposal";
+import { LargeGrantProposal } from "./_components/LargeGrantProposal";
+import { LargeMilestoneCompleted } from "./_components/LargeMilestoneCompleted";
+import { Proposal } from "./_components/Proposal";
 import type { NextPage } from "next";
 import { getServerSession } from "next-auth";
 import { SignInBtn } from "~~/components/pg-ens/SignInBtn";
 import { getAllGrantsWithStagesAndPrivateNotes } from "~~/services/database/repositories/grants";
+import { getAllLargeGrantsWithStagesAndPrivateNotes } from "~~/services/database/repositories/large-grants";
+import { getCompledOrVerifiedMilestones } from "~~/services/database/repositories/large-milestones";
+import { DiscriminatedGrantWithStagesAndPrivateNotes } from "~~/types/utils";
 import { authOptions } from "~~/utils/auth";
 
 export const revalidate = 0;
@@ -25,11 +30,19 @@ const Admin: NextPage = async () => {
     return redirect("/");
   }
 
-  const allGrants = await getAllGrantsWithStagesAndPrivateNotes();
+  const grants = (await getAllGrantsWithStagesAndPrivateNotes()).map(grant => ({ ...grant, type: "grant" }));
+  const largeGrants = (await getAllLargeGrantsWithStagesAndPrivateNotes()).map(grant => ({
+    ...grant,
+    type: "largeGrant",
+  }));
+
+  const allGrants = ([...grants, ...largeGrants] as DiscriminatedGrantWithStagesAndPrivateNotes[]).sort(
+    (a, b) => (b.submitedAt?.getTime() ?? 0) - (a.submitedAt?.getTime() ?? 0),
+  );
 
   const submissionsByBuilderAddress: { [key: string]: number } = {};
-  const grantProposals: Array<NonNullable<GrantWithStagesAndPrivateNotes>> = [];
-  const stageProposals: Array<NonNullable<GrantWithStagesAndPrivateNotes>> = [];
+  const grantProposals: Array<NonNullable<DiscriminatedGrantWithStagesAndPrivateNotes>> = [];
+  const stageProposals: Array<NonNullable<DiscriminatedGrantWithStagesAndPrivateNotes>> = [];
 
   allGrants.forEach(grant => {
     const latestStage = grant.stages[0];
@@ -48,34 +61,62 @@ const Admin: NextPage = async () => {
     }
   });
 
+  const milestones = await getCompledOrVerifiedMilestones();
+
   return (
     <div className="flex flex-col flex-grow px-4 py-10 sm:py-20">
       <h1 className="text-3xl text-center font-extrabold !mb-0">Pending proposals</h1>
 
-      <div className="mt-10 mx-auto grid md:grid-cols-2 gap-4 sm:gap-8 w-full sm:max-w-6xl">
+      <div className="mt-10 mx-auto grid md:grid-cols-3 gap-4 sm:gap-8 w-full">
         <div className="flex flex-col items-center p-4 sm:p-6 bg-[#FBE6F4] rounded-xl">
           <h2 className="text-2xl font-bold !m-0">New Grant Proposals ({grantProposals.length})</h2>
           <div className="mt-4 sm:mt-6 space-y-4 w-full flex flex-col items-center">
-            {grantProposals.map(grant => (
-              <Proposal
-                key={grant.id}
-                proposal={grant}
-                userSubmissionsAmount={submissionsByBuilderAddress[grant.builderAddress]}
-                isGrant
-              />
-            ))}
+            {grantProposals.map(grant =>
+              grant.type === "largeGrant" ? (
+                <LargeGrantProposal
+                  key={`${grant.type}-${grant.id}`}
+                  proposal={grant}
+                  userSubmissionsAmount={submissionsByBuilderAddress[grant.builderAddress]}
+                  isGrant
+                />
+              ) : (
+                <Proposal
+                  key={`${grant.type}-${grant.id}`}
+                  proposal={grant}
+                  userSubmissionsAmount={submissionsByBuilderAddress[grant.builderAddress]}
+                  isGrant
+                />
+              ),
+            )}
           </div>
         </div>
 
         <div className="flex flex-col items-center p-4 sm:p-6 bg-[#F3E6FB] rounded-xl">
           <h2 className="text-2xl font-bold !m-0">New Stage Proposals ({stageProposals.length})</h2>
           <div className="mt-4 sm:mt-6 space-y-4 w-full flex flex-col items-center">
-            {stageProposals.map(grant => (
-              <Proposal
-                key={grant.id}
-                proposal={grant}
-                userSubmissionsAmount={submissionsByBuilderAddress[grant.builderAddress]}
-              />
+            {stageProposals.map(grant =>
+              grant.type === "largeGrant" ? (
+                <LargeGrantProposal
+                  key={`${grant.type}-${grant.id}`}
+                  proposal={grant}
+                  userSubmissionsAmount={submissionsByBuilderAddress[grant.builderAddress]}
+                />
+              ) : (
+                <Proposal
+                  key={`${grant.type}-${grant.id}`}
+                  proposal={grant}
+                  userSubmissionsAmount={submissionsByBuilderAddress[grant.builderAddress]}
+                />
+              ),
+            )}
+          </div>
+        </div>
+
+        <div className="flex flex-col items-center p-4 sm:p-6 bg-light-purple rounded-xl">
+          <h2 className="text-2xl font-bold !m-0">Milestones to Review ({milestones.length})</h2>
+          <div className="mt-4 sm:mt-6 space-y-4 w-full flex flex-col items-center">
+            {milestones.map(milestone => (
+              <LargeMilestoneCompleted key={milestone.id} milestone={milestone} />
             ))}
           </div>
         </div>

--- a/packages/nextjs/app/api/large-milestones/[milestoneId]/private-note/route.ts
+++ b/packages/nextjs/app/api/large-milestones/[milestoneId]/private-note/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { recoverTypedDataAddress } from "viem";
+import {
+  PrivateNoteModalFormValues,
+  privateNoteModalFormSchema,
+} from "~~/app/admin/_components/PrivateNoteModal/schema";
+import { createLargeMilestonePrivateNote } from "~~/services/database/repositories/large-milestone-private-notes";
+import { authOptions } from "~~/utils/auth";
+import { EIP_712_DOMAIN, EIP_712_TYPES__LARGE_MILESTONE_PRIVATE_NOTE } from "~~/utils/eip712";
+
+export type MilestonePrivateNoteReqBody = PrivateNoteModalFormValues & { signature: `0x${string}` };
+
+export async function POST(req: NextRequest, { params }: { params: { milestoneId: string } }) {
+  try {
+    const { milestoneId } = params;
+    const session = await getServerSession(authOptions);
+
+    const body = (await req.json()) as MilestonePrivateNoteReqBody;
+    const { note, signature } = body;
+
+    const recoveredAddress = await recoverTypedDataAddress({
+      domain: EIP_712_DOMAIN,
+      types: EIP_712_TYPES__LARGE_MILESTONE_PRIVATE_NOTE,
+      primaryType: "Message",
+      message: {
+        milestoneId,
+        note,
+      },
+      signature,
+    });
+
+    if (session?.user.address !== recoveredAddress)
+      return NextResponse.json({ error: "Recovered address did not match session address" }, { status: 403 });
+
+    if (session?.user.role !== "admin") {
+      return NextResponse.json({ error: "Only admins can review milestones" }, { status: 403 });
+    }
+
+    try {
+      privateNoteModalFormSchema.parse({ note });
+    } catch (err) {
+      return NextResponse.json({ error: "Invalid form details submitted" }, { status: 400 });
+    }
+
+    const privateNoteId = await createLargeMilestonePrivateNote({
+      milestoneId: Number(milestoneId),
+      note,
+      authorAddress: session.user.address,
+    });
+
+    return NextResponse.json({ privateNoteId }, { status: 200 });
+  } catch (e) {
+    return NextResponse.json({ error: "Error creating private note" }, { status: 500 });
+  }
+}

--- a/packages/nextjs/app/api/large-milestones/[milestoneId]/review/route.ts
+++ b/packages/nextjs/app/api/large-milestones/[milestoneId]/review/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { recoverTypedDataAddress } from "viem";
+import {
+  LargeMilestoneUpdate,
+  getMilestoneByIdWithRelatedData,
+  updateMilestone,
+} from "~~/services/database/repositories/large-milestones";
+import { authOptions } from "~~/utils/auth";
+import { EIP_712_DOMAIN, EIP_712_TYPES__REVIEW_LARGE_MILESTONE } from "~~/utils/eip712";
+
+export type ReviewMilestoneBody = {
+  status: Required<LargeMilestoneUpdate>["status"];
+  verifiedTx?: LargeMilestoneUpdate["verifiedTx"];
+  paymentTx?: LargeMilestoneUpdate["paymentTx"];
+  statusNote?: LargeMilestoneUpdate["statusNote"];
+  signature: `0x${string}`;
+};
+
+export async function POST(req: NextRequest, { params }: { params: { milestoneId: string } }) {
+  try {
+    const { milestoneId } = params;
+    const body = (await req.json()) as ReviewMilestoneBody;
+    const session = await getServerSession(authOptions);
+    const milestone = await getMilestoneByIdWithRelatedData(Number(milestoneId));
+
+    if (!milestone) return NextResponse.json({ error: "Milestone not found" }, { status: 404 });
+
+    const recoveredAddress = await recoverTypedDataAddress({
+      domain: EIP_712_DOMAIN,
+      types: EIP_712_TYPES__REVIEW_LARGE_MILESTONE,
+      primaryType: "Message",
+      message: {
+        milestoneId,
+        action: body.status,
+        txHash: body.verifiedTx || body.paymentTx || "",
+        statusNote: body.statusNote || "",
+      },
+      signature: body.signature,
+    });
+
+    if (body.status === "completed" && session?.user.address !== milestone.stage.grant.builderAddress) {
+      return NextResponse.json({ error: "Only grant owner can complete milestones" }, { status: 401 });
+    }
+
+    if (body.status !== "completed" && session?.user.role !== "admin") {
+      return NextResponse.json({ error: "Only admins can review stages" }, { status: 401 });
+    }
+
+    if (session?.user.address !== recoveredAddress)
+      return NextResponse.json({ error: "Recovered address did not match session address" }, { status: 403 });
+
+    if (body.status === "verified" && !body.verifiedTx) {
+      return NextResponse.json({ error: "Verified milestones must have a transaction hash" }, { status: 400 });
+    }
+
+    if (body.status === "paid" && !body.paymentTx) {
+      return NextResponse.json({ error: "Paid milestones must have a transaction hash" }, { status: 400 });
+    }
+
+    if (body.status === "paid" && milestone.status !== "verified") {
+      return NextResponse.json({ error: "Milestone not verified yet" }, { status: 400 });
+    }
+
+    const verifiedObj = body.verifiedTx
+      ? {
+          verifiedTx: body.verifiedTx,
+          verifiedAt: new Date(),
+          verifiedBy: session?.user.address,
+        }
+      : {};
+
+    const paymentObj = body.paymentTx
+      ? {
+          paymentTx: body.paymentTx,
+          paidAt: new Date(),
+          paidBy: session?.user.address,
+        }
+      : {};
+
+    await updateMilestone(Number(milestoneId), {
+      status: body.status,
+      statusNote: body.statusNote,
+      ...verifiedObj,
+      ...paymentObj,
+    });
+
+    return NextResponse.json({ milestoneId, status: body.status }, { status: 200 });
+  } catch (e) {
+    return NextResponse.json({ error: "Error processing form" }, { status: 500 });
+  }
+}

--- a/packages/nextjs/app/api/large-milestones/[milestoneId]/review/route.ts
+++ b/packages/nextjs/app/api/large-milestones/[milestoneId]/review/route.ts
@@ -82,12 +82,20 @@ export async function POST(req: NextRequest, { params }: { params: { milestoneId
           }
         : {};
 
+    const completedObj =
+      body.status === "completed"
+        ? {
+            completedAt: new Date(),
+          }
+        : {};
+
     await updateMilestone(Number(milestoneId), {
       status: body.status,
       statusNote: session?.user.role === "admin" ? body.statusNote : undefined,
       completionProof: body.completionProof,
       ...verifiedObj,
       ...paymentObj,
+      ...completedObj,
     });
 
     // check if this is the last milestone of the stage and update the stage status to "completed"

--- a/packages/nextjs/app/api/large-milestones/[milestoneId]/review/route.ts
+++ b/packages/nextjs/app/api/large-milestones/[milestoneId]/review/route.ts
@@ -44,7 +44,7 @@ export async function POST(req: NextRequest, { params }: { params: { milestoneId
     }
 
     if (body.status !== "completed" && session?.user.role !== "admin") {
-      return NextResponse.json({ error: "Only admins can review stages" }, { status: 401 });
+      return NextResponse.json({ error: "Only admins can review milestones" }, { status: 401 });
     }
 
     if (session?.user.address !== recoveredAddress)

--- a/packages/nextjs/app/api/large-stages/[stageId]/approval-vote/route.ts
+++ b/packages/nextjs/app/api/large-stages/[stageId]/approval-vote/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { recoverTypedDataAddress } from "viem";
+import { createLargeApprovalVote } from "~~/services/database/repositories/large-approval-votes";
+import { authOptions } from "~~/utils/auth";
+import { EIP_712_DOMAIN, EIP_712_TYPES__LARGE_STAGE_APPROVAL_VOTE } from "~~/utils/eip712";
+
+export type ApprovalVoteReqBody = { signature: `0x${string}` };
+
+export async function POST(req: NextRequest, { params }: { params: { stageId: string } }) {
+  try {
+    const { stageId } = params;
+    const session = await getServerSession(authOptions);
+
+    const body = (await req.json()) as ApprovalVoteReqBody;
+    const { signature } = body;
+
+    const recoveredAddress = await recoverTypedDataAddress({
+      domain: EIP_712_DOMAIN,
+      types: EIP_712_TYPES__LARGE_STAGE_APPROVAL_VOTE,
+      primaryType: "Message",
+      message: {
+        stageId,
+      },
+      signature,
+    });
+
+    if (session?.user.address !== recoveredAddress)
+      return NextResponse.json({ error: "Recovered address did not match session address" }, { status: 403 });
+
+    if (session?.user.role !== "admin") {
+      return NextResponse.json({ error: "Only admins can review stages" }, { status: 403 });
+    }
+
+    const approvalVoteId = await createLargeApprovalVote({
+      stageId: Number(stageId),
+      authorAddress: session.user.address,
+    });
+
+    return NextResponse.json({ approvalVoteId }, { status: 200 });
+  } catch (e) {
+    return NextResponse.json({ error: "Error creating approval vote" }, { status: 500 });
+  }
+}

--- a/packages/nextjs/app/api/large-stages/[stageId]/private-note/route.ts
+++ b/packages/nextjs/app/api/large-stages/[stageId]/private-note/route.ts
@@ -1,0 +1,6 @@
+import { NextRequest } from "next/server";
+import { createPrivateNoteRequest } from "~~/app/api/stages/[stageId]/private-note/route";
+
+export async function POST(req: NextRequest, { params }: { params: { stageId: string } }) {
+  return createPrivateNoteRequest(req, { params, isLargeGrant: true });
+}

--- a/packages/nextjs/app/api/large-stages/[stageId]/reject-vote/route.ts
+++ b/packages/nextjs/app/api/large-stages/[stageId]/reject-vote/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { recoverTypedDataAddress } from "viem";
+import { createLargeRejectVote } from "~~/services/database/repositories/large-reject-votes";
+import {
+  LargeStageUpdate,
+  getStageByIdWithGrantAndVotes,
+  updateStage,
+} from "~~/services/database/repositories/large-stages";
+import { MINIMAL_VOTES_FOR_FINAL_APPROVAL } from "~~/utils/approval-votes";
+import { authOptions } from "~~/utils/auth";
+import { EIP_712_DOMAIN, EIP_712_TYPES__LARGE_STAGE_REJECT_VOTE } from "~~/utils/eip712";
+
+export type RejectVoteReqBody = { statusNote?: LargeStageUpdate["statusNote"]; signature: `0x${string}` };
+
+export async function POST(req: NextRequest, { params }: { params: { stageId: string } }) {
+  try {
+    const { stageId } = params;
+    const session = await getServerSession(authOptions);
+
+    const body = (await req.json()) as RejectVoteReqBody;
+    const signature = body.signature;
+
+    const recoveredAddress = await recoverTypedDataAddress({
+      domain: EIP_712_DOMAIN,
+      types: EIP_712_TYPES__LARGE_STAGE_REJECT_VOTE,
+      primaryType: "Message",
+      message: {
+        stageId,
+        statusNote: body.statusNote || "",
+      },
+      signature,
+    });
+
+    if (session?.user.address !== recoveredAddress)
+      return NextResponse.json({ error: "Recovered address did not match session address" }, { status: 403 });
+
+    if (session?.user.role !== "admin") {
+      return NextResponse.json({ error: "Only admins can reject stages" }, { status: 403 });
+    }
+
+    const rejectVoteId = await createLargeRejectVote({
+      stageId: Number(stageId),
+      authorAddress: session.user.address,
+    });
+
+    const grant = await getStageByIdWithGrantAndVotes(Number(stageId));
+    if (grant && grant.rejectVotes.length === MINIMAL_VOTES_FOR_FINAL_APPROVAL) {
+      await updateStage(Number(stageId), {
+        status: "rejected",
+        statusNote: body.statusNote || "",
+      });
+    }
+
+    return NextResponse.json({ rejectVoteId }, { status: 200 });
+  } catch (e) {
+    return NextResponse.json({ error: "Error creating reject vote" }, { status: 500 });
+  }
+}

--- a/packages/nextjs/app/api/large-stages/[stageId]/review/route.ts
+++ b/packages/nextjs/app/api/large-stages/[stageId]/review/route.ts
@@ -1,0 +1,88 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { recoverTypedDataAddress } from "viem";
+import {
+  LargeStageUpdate,
+  approveStage,
+  getStageByIdWithGrantAndVotes,
+  updateStage,
+} from "~~/services/database/repositories/large-stages";
+import { MINIMAL_VOTES_FOR_FINAL_APPROVAL } from "~~/utils/approval-votes";
+import { authOptions } from "~~/utils/auth";
+import { EIP_712_DOMAIN, EIP_712_TYPES__REVIEW_LARGE_STAGE } from "~~/utils/eip712";
+
+export type ReviewStageBody = {
+  status: Required<LargeStageUpdate>["status"];
+  approvedTx?: LargeStageUpdate["approvedTx"];
+  statusNote?: LargeStageUpdate["statusNote"];
+  signature: `0x${string}`;
+};
+
+export async function POST(req: NextRequest, { params }: { params: { stageId: string } }) {
+  try {
+    const { stageId } = params;
+    const body = (await req.json()) as ReviewStageBody;
+    const session = await getServerSession(authOptions);
+    const stage = await getStageByIdWithGrantAndVotes(Number(stageId));
+
+    const recoveredAddress = await recoverTypedDataAddress({
+      domain: EIP_712_DOMAIN,
+      types: EIP_712_TYPES__REVIEW_LARGE_STAGE,
+      primaryType: "Message",
+      message: {
+        stageId,
+        action: body.status,
+        txHash: body.approvedTx || "",
+        statusNote: body.statusNote || "",
+      },
+      signature: body.signature,
+    });
+
+    if (body.status === "completed" && session?.user.address !== stage?.grant.builderAddress) {
+      return NextResponse.json({ error: "Only grant owner can complete stages" }, { status: 401 });
+    }
+
+    // TODO: Don't do admin check if the status is completed. The status will be marked completed probably through contract event
+    if (body.status !== "completed" && session?.user.role !== "admin") {
+      return NextResponse.json({ error: "Only admins can review stages" }, { status: 401 });
+    }
+
+    if (session?.user.address !== recoveredAddress)
+      return NextResponse.json({ error: "Recovered address did not match session address" }, { status: 403 });
+
+    if (body.status === "approved" && !body.approvedTx) {
+      return NextResponse.json({ error: "Approved grants must have a transaction hash" }, { status: 400 });
+    }
+
+    if (
+      body.status === "approved" &&
+      (!stage?.approvalVotes || stage.approvalVotes.length < MINIMAL_VOTES_FOR_FINAL_APPROVAL)
+    ) {
+      return NextResponse.json({ error: "Not enough votes for final approval" }, { status: 400 });
+    }
+
+    const approvedObj = body.approvedTx
+      ? {
+          approvedTx: body.approvedTx,
+          approvedAt: new Date(),
+        }
+      : {};
+
+    if (body.status === "approved") {
+      await approveStage(Number(stageId), {
+        statusNote: body.statusNote,
+        ...approvedObj,
+      });
+    } else {
+      await updateStage(Number(stageId), {
+        status: body.status,
+        statusNote: body.statusNote,
+        ...approvedObj,
+      });
+    }
+
+    return NextResponse.json({ stageId, status: body.status }, { status: 200 });
+  } catch (e) {
+    return NextResponse.json({ error: "Error processing form" }, { status: 500 });
+  }
+}

--- a/packages/nextjs/app/api/large-stages/new/route.ts
+++ b/packages/nextjs/app/api/large-stages/new/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { recoverTypedDataAddress } from "viem";
+import { newStageModalFormSchema } from "~~/app/large-grants/[grantId]/_components/CurrentStage/NewStageModal/schema";
+import { getLargeGrantById } from "~~/services/database/repositories/large-grants";
+import { LargeStageInsertWithMilestones, createStage } from "~~/services/database/repositories/large-stages";
+import { notifyTelegramBot } from "~~/services/notifications/telegram";
+import { authOptions } from "~~/utils/auth";
+import { EIP_712_DOMAIN, EIP_712_TYPES__APPLY_FOR_LARGE_STAGE } from "~~/utils/eip712";
+
+export type CreateNewLargeStageReqBody = LargeStageInsertWithMilestones & { signature: `0x${string}` };
+
+export async function POST(req: Request) {
+  try {
+    const session = await getServerSession(authOptions);
+    const body = (await req.json()) as CreateNewLargeStageReqBody;
+
+    try {
+      newStageModalFormSchema.parse({ milestones: body.milestones });
+    } catch (err) {
+      return NextResponse.json({ error: "Invalid form details submitted" }, { status: 400 });
+    }
+
+    const { signature, ...newStage } = body;
+
+    const grant = await getLargeGrantById(newStage.grantId);
+    if (!grant) return NextResponse.json({ error: "Grant not found" }, { status: 404 });
+    const latestStage = grant.stages[grant.stages.length - 1];
+
+    const recoveredAddress = await recoverTypedDataAddress({
+      domain: EIP_712_DOMAIN,
+      types: EIP_712_TYPES__APPLY_FOR_LARGE_STAGE,
+      primaryType: "Message",
+      message: {
+        stage_number: (latestStage.stageNumber + 1).toString(),
+        milestones: JSON.stringify(newStage.milestones),
+      },
+      signature,
+    });
+
+    if (grant.builderAddress !== session?.user.address)
+      return NextResponse.json({ error: "Only owner can apply for new stage" }, { status: 401 });
+
+    if (session?.user.address !== recoveredAddress)
+      return NextResponse.json({ error: "Recovered address did not match session address" }, { status: 403 });
+
+    // check if previous stage was completed
+    if (latestStage.status !== "completed") {
+      return NextResponse.json(
+        { error: "Previous stage must be completed before applying for a new stage" },
+        { status: 403 },
+      );
+    }
+
+    const formattedNewStage = {
+      ...newStage,
+      milestones: newStage.milestones.map(milestone => ({
+        ...milestone,
+        proposedCompletionDate:
+          milestone.proposedCompletionDate instanceof Date
+            ? milestone.proposedCompletionDate
+            : new Date(milestone.proposedCompletionDate),
+      })),
+    };
+
+    const createdStage = await createStage({
+      grantId: newStage.grantId,
+      milestones: formattedNewStage.milestones,
+      stageNumber: latestStage.stageNumber + 1,
+    });
+
+    await notifyTelegramBot("largeStage", {
+      newLargeStage: body,
+    });
+
+    return NextResponse.json({ stageId: createdStage.stageId }, { status: 201 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: "Error creating grant" }, { status: 500 });
+  }
+}

--- a/packages/nextjs/app/large-grant-apply/page.tsx
+++ b/packages/nextjs/app/large-grant-apply/page.tsx
@@ -81,9 +81,8 @@ const LargeGrantApply: NextPage = () => {
     name: "milestones",
   });
 
-  const watchMilestones = watch(["milestones"]);
-
-  const totalAmount = watchMilestones[0].reduce((acc, curr) => acc + Number(curr.amount), 0);
+  const watchMilestones = watch("milestones");
+  const totalAmount = watchMilestones.reduce((acc, curr) => acc + Number(curr.amount), 0);
 
   return (
     <div className="flex flex-col w-full items-center justify-center p-6 sm:p-10">

--- a/packages/nextjs/app/large-grant-apply/page.tsx
+++ b/packages/nextjs/app/large-grant-apply/page.tsx
@@ -128,12 +128,13 @@ const LargeGrantApply: NextPage = () => {
                 {fields.map((field, index) => (
                   <div key={field.id}>
                     {index > 0 && <hr className="border-t border-white my-6" />}
-                    <h4 className="text-2xl font-bold">
-                      Milestone {index + 1}
-                      <button type="button" onClick={() => remove(index)} className="ml-2">
+                    <div className="flex items-center justify-between mb-4">
+                      <h4 className="text-2xl font-bold">Milestone {index + 1}</h4>
+                      <Button variant="secondary" size="sm" onClick={() => remove(index)} className="ml-2">
                         <TrashIcon className="h-4 w-4" />
-                      </button>
-                    </h4>
+                        <span className="hidden sm:inline">Delete milestone</span>
+                      </Button>
+                    </div>
                     <FormTextarea
                       label="Description"
                       showMessageLength

--- a/packages/nextjs/app/large-grant-apply/schema.ts
+++ b/packages/nextjs/app/large-grant-apply/schema.ts
@@ -1,7 +1,7 @@
 import * as z from "zod";
 import { DEFAULT_INPUT_MAX_LENGTH, DEFAULT_TEXTAREA_MAX_LENGTH } from "~~/utils/forms";
 
-const milestoneSchema = z.object({
+export const milestoneSchema = z.object({
   description: z.string().min(20, { message: "At least 20 characters required" }).max(DEFAULT_TEXTAREA_MAX_LENGTH),
   proposedDeliverables: z
     .string()

--- a/packages/nextjs/app/large-grants/[grantId]/_components/CurrentStage/CompleteMilestoneModal/index.tsx
+++ b/packages/nextjs/app/large-grants/[grantId]/_components/CurrentStage/CompleteMilestoneModal/index.tsx
@@ -6,6 +6,7 @@ import { Toaster } from "react-hot-toast";
 import { Button } from "~~/components/pg-ens/Button";
 import { FormTextarea } from "~~/components/pg-ens/form-fields/FormTextarea";
 import { useFormMethods } from "~~/hooks/pg-ens/useFormMethods";
+import { useLargeMilestoneReview } from "~~/hooks/pg-ens/useLargeMilestoneReview";
 import { LargeMilestone } from "~~/services/database/repositories/large-milestones";
 import { multilineStringToTsx } from "~~/utils/multiline-string-to-tsx";
 
@@ -17,6 +18,7 @@ type WithdrawModalProps = {
 export const CompleteMilestoneModal = forwardRef<HTMLDialogElement, WithdrawModalProps>(
   ({ closeModal, milestone }, ref) => {
     const router = useRouter();
+    const { reviewMilestone } = useLargeMilestoneReview(milestone.id);
 
     const { formMethods, getCommonOptions } = useFormMethods<CompleteMilestoneModalFormValues>({
       schema: completeMilestoneModalFormSchema,
@@ -25,11 +27,8 @@ export const CompleteMilestoneModal = forwardRef<HTMLDialogElement, WithdrawModa
 
     const onSubmit = async (fieldValues: CompleteMilestoneModalFormValues) => {
       try {
-        const { proofOfCompletion } = fieldValues;
-
-        // TODO: implement the logic to complete the milestone
-        console.log("Completing milestone with proof of completion:", proofOfCompletion);
-
+        const { completionProof } = fieldValues;
+        await reviewMilestone({ status: "completed", completionProof });
         closeModal();
         clearFormValues();
         router.refresh();
@@ -56,11 +55,7 @@ export const CompleteMilestoneModal = forwardRef<HTMLDialogElement, WithdrawModa
             </div>
             <form onSubmit={handleSubmit(onSubmit)} className="w-full flex flex-col space-y-1">
               <div className="flex flex-col">
-                <FormTextarea
-                  label="Proof of completion"
-                  showMessageLength
-                  {...getCommonOptions("proofOfCompletion")}
-                />
+                <FormTextarea label="Proof of completion" showMessageLength {...getCommonOptions("completionProof")} />
                 <span className="text-sm italic text-right pb-4">
                   *Video walkthrough, GitHub repo or other deliverables
                 </span>

--- a/packages/nextjs/app/large-grants/[grantId]/_components/CurrentStage/CompleteMilestoneModal/schema.tsx
+++ b/packages/nextjs/app/large-grants/[grantId]/_components/CurrentStage/CompleteMilestoneModal/schema.tsx
@@ -2,10 +2,7 @@ import * as z from "zod";
 import { DEFAULT_TEXTAREA_MAX_LENGTH } from "~~/utils/forms";
 
 export const completeMilestoneModalFormSchema = z.object({
-  proofOfCompletion: z
-    .string()
-    .min(20, { message: "At least 20 characters required" })
-    .max(DEFAULT_TEXTAREA_MAX_LENGTH),
+  completionProof: z.string().min(20, { message: "At least 20 characters required" }).max(DEFAULT_TEXTAREA_MAX_LENGTH),
 });
 
 export type CompleteMilestoneModalFormValues = z.infer<typeof completeMilestoneModalFormSchema>;

--- a/packages/nextjs/app/large-grants/[grantId]/_components/CurrentStage/MilestoneDetail.tsx
+++ b/packages/nextjs/app/large-grants/[grantId]/_components/CurrentStage/MilestoneDetail.tsx
@@ -47,6 +47,9 @@ export const MilestoneDetail = ({ milestone }: { milestone: LargeMilestone }) =>
                   </a>
                 </div>
               )}
+              {milestone.status === "rejected" && milestone.statusNote && (
+                <div className="mt-2 ml-4 text-sm font-bold text-gray-400">Note: {milestone.statusNote}</div>
+              )}
             </div>
           )}
         </div>

--- a/packages/nextjs/app/large-grants/[grantId]/_components/CurrentStage/MilestoneDetail.tsx
+++ b/packages/nextjs/app/large-grants/[grantId]/_components/CurrentStage/MilestoneDetail.tsx
@@ -5,6 +5,7 @@ import { CompleteMilestoneModal } from "./CompleteMilestoneModal";
 import { BadgeMilestone } from "~~/components/pg-ens/BadgeMilestone";
 import { Button } from "~~/components/pg-ens/Button";
 import { LargeMilestone } from "~~/services/database/repositories/large-milestones";
+import { getFormattedDateWithDay, getFormattedDeadline } from "~~/utils/getFormattedDate";
 import { multilineStringToTsx } from "~~/utils/multiline-string-to-tsx";
 
 export const MilestoneDetail = ({ milestone }: { milestone: LargeMilestone }) => {
@@ -16,7 +17,7 @@ export const MilestoneDetail = ({ milestone }: { milestone: LargeMilestone }) =>
         <div className="flex justify-between items-center">
           <div>
             <div className="text-xl font-bold">Milestone {milestone.milestoneNumber}</div>
-            <div className="text-sm font-bold">Deadline: {milestone.proposedCompletionDate.toLocaleDateString()}</div>
+            <div className="text-sm font-bold">Deadline: {getFormattedDeadline(milestone.proposedCompletionDate)}</div>
           </div>
           <div className="bg-white rounded-lg p-1 font-bold">{milestone.amount.toLocaleString()} USDC</div>
         </div>
@@ -50,7 +51,7 @@ export const MilestoneDetail = ({ milestone }: { milestone: LargeMilestone }) =>
                 )}
                 {milestone.status === "paid" && milestone.paidAt && (
                   <div className="mt-2 ml-4 text-sm font-bold text-gray-400">
-                    Paid on {milestone.paidAt.toLocaleString()} -
+                    Paid on {getFormattedDateWithDay(milestone.paidAt)} -
                     <a
                       href={`https://optimistic.etherscan.io/tx/${milestone.paymentTx}`}
                       target="_blank"

--- a/packages/nextjs/app/large-grants/[grantId]/_components/CurrentStage/MilestoneDetail.tsx
+++ b/packages/nextjs/app/large-grants/[grantId]/_components/CurrentStage/MilestoneDetail.tsx
@@ -22,7 +22,15 @@ export const MilestoneDetail = ({ milestone }: { milestone: LargeMilestone }) =>
         </div>
         <div className="flex flex-col gap-4">
           <div>{multilineStringToTsx(milestone.description)}</div>
-          {milestone.completionProof && <div>Completion Proof: {milestone.completionProof}</div>}
+          <div>
+            <span className="font-semibold">Proposed Deliverables:</span>{" "}
+            {multilineStringToTsx(milestone.proposedDeliverables)}
+          </div>
+          {milestone.completionProof && (
+            <div>
+              <span className="font-semibold">Completion Proof:</span> {multilineStringToTsx(milestone.completionProof)}
+            </div>
+          )}
           {milestone.status === "approved" ? (
             <Button
               className="w-auto self-start"

--- a/packages/nextjs/app/large-grants/[grantId]/_components/CurrentStage/MilestoneDetail.tsx
+++ b/packages/nextjs/app/large-grants/[grantId]/_components/CurrentStage/MilestoneDetail.tsx
@@ -22,6 +22,7 @@ export const MilestoneDetail = ({ milestone }: { milestone: LargeMilestone }) =>
         </div>
         <div className="flex flex-col gap-4">
           <div>{multilineStringToTsx(milestone.description)}</div>
+          {milestone.completionProof && <div>Completion Proof: {milestone.completionProof}</div>}
           {milestone.status === "approved" ? (
             <Button
               className="w-auto self-start"
@@ -32,25 +33,27 @@ export const MilestoneDetail = ({ milestone }: { milestone: LargeMilestone }) =>
               Complete
             </Button>
           ) : (
-            <div className="flex flex-row">
-              <BadgeMilestone status={milestone.status} />
-              {milestone.status === "paid" && milestone.paidAt && (
-                <div className="mt-2 ml-4 text-sm font-bold text-gray-400">
-                  Paid on {milestone.paidAt.toLocaleString()} -
-                  <a
-                    href={`https://optimistic.etherscan.io/tx/${milestone.paymentTx}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="ml-1 underline"
-                  >
-                    See transaction details
-                  </a>
-                </div>
-              )}
-              {milestone.status === "rejected" && milestone.statusNote && (
-                <div className="mt-2 ml-4 text-sm font-bold text-gray-400">Note: {milestone.statusNote}</div>
-              )}
-            </div>
+            milestone.status !== "proposed" && (
+              <div className="flex flex-row">
+                <BadgeMilestone status={milestone.status} />
+                {["rejected", "paid"].includes(milestone.status) && milestone.statusNote && (
+                  <div className="mt-2 ml-4 text-sm font-bold text-gray-400">Note: {milestone.statusNote}</div>
+                )}
+                {milestone.status === "paid" && milestone.paidAt && (
+                  <div className="mt-2 ml-4 text-sm font-bold text-gray-400">
+                    Paid on {milestone.paidAt.toLocaleString()} -
+                    <a
+                      href={`https://optimistic.etherscan.io/tx/${milestone.paymentTx}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="ml-1 underline"
+                    >
+                      See transaction details
+                    </a>
+                  </div>
+                )}
+              </div>
+            )
           )}
         </div>
       </div>

--- a/packages/nextjs/app/large-grants/[grantId]/_components/CurrentStage/MilestoneDetail.tsx
+++ b/packages/nextjs/app/large-grants/[grantId]/_components/CurrentStage/MilestoneDetail.tsx
@@ -34,6 +34,7 @@ export const MilestoneDetail = ({ milestone }: { milestone: LargeMilestone }) =>
           {milestone.status === "approved" ? (
             <Button
               className="w-auto self-start"
+              size="sm"
               onClick={() => {
                 completeMilestoneModalRef.current?.showModal();
               }}
@@ -62,6 +63,17 @@ export const MilestoneDetail = ({ milestone }: { milestone: LargeMilestone }) =>
                 )}
               </div>
             )
+          )}
+          {milestone.status === "rejected" && (
+            <Button
+              className="w-auto self-start"
+              size="sm"
+              onClick={() => {
+                completeMilestoneModalRef.current?.showModal();
+              }}
+            >
+              Submit again
+            </Button>
           )}
         </div>
       </div>

--- a/packages/nextjs/app/large-grants/[grantId]/_components/CurrentStage/NewStageModal/index.tsx
+++ b/packages/nextjs/app/large-grants/[grantId]/_components/CurrentStage/NewStageModal/index.tsx
@@ -1,0 +1,210 @@
+import { forwardRef, useRef } from "react";
+import { useRouter } from "next/navigation";
+import { NewStageModalFormValues, newStageModalFormSchema } from "./schema";
+import { useMutation } from "@tanstack/react-query";
+import { FormProvider, useFieldArray } from "react-hook-form";
+import { Toaster } from "react-hot-toast";
+import { useSignTypedData } from "wagmi";
+import { TrashIcon } from "@heroicons/react/20/solid";
+import { CreateNewLargeStageReqBody } from "~~/app/api/large-stages/new/route";
+import { Button } from "~~/components/pg-ens/Button";
+import { FormInputDate } from "~~/components/pg-ens/form-fields/FormInputDate";
+import { FormInputNumber } from "~~/components/pg-ens/form-fields/FormInputNumber";
+import { FormTextarea } from "~~/components/pg-ens/form-fields/FormTextarea";
+import { useFormMethods } from "~~/hooks/pg-ens/useFormMethods";
+import { LargeGrant } from "~~/services/database/repositories/large-grants";
+import { LargeStageWithMilestones } from "~~/services/database/repositories/large-stages";
+import { EIP_712_DOMAIN, EIP_712_TYPES__APPLY_FOR_LARGE_STAGE } from "~~/utils/eip712";
+import { postMutationFetcher } from "~~/utils/react-query";
+import { getParsedError, notification } from "~~/utils/scaffold-eth";
+
+type NewStageModalProps = {
+  grantId: LargeGrant["id"];
+  closeModal: () => void;
+  previousStage: LargeStageWithMilestones;
+};
+
+export const NewStageModal = forwardRef<HTMLDialogElement, NewStageModalProps>(
+  ({ grantId, closeModal, previousStage }, ref) => {
+    const { formMethods } = useFormMethods<NewStageModalFormValues>({
+      schema: newStageModalFormSchema,
+      defaultValues: {
+        milestones: [{ description: "", proposedDeliverables: "", amount: 0, proposedCompletionDate: new Date() }],
+      },
+    });
+
+    const {
+      handleSubmit,
+      control,
+      watch,
+      formState: { errors },
+    } = formMethods;
+
+    const feedbackModalRef = useRef<HTMLDialogElement>(null);
+
+    const onSubmit = async (fieldValues: NewStageModalFormValues) => {
+      try {
+        const milestones = fieldValues.milestones;
+
+        const signature = await signTypedDataAsync({
+          domain: EIP_712_DOMAIN,
+          types: EIP_712_TYPES__APPLY_FOR_LARGE_STAGE,
+          primaryType: "Message",
+          message: {
+            stage_number: (previousStage.stageNumber + 1).toString(),
+            milestones: JSON.stringify(milestones),
+          },
+        });
+
+        await postNewStage({ milestones, signature, grantId });
+        closeModal();
+        feedbackModalRef.current?.showModal();
+      } catch (error) {
+        const errorMessage = getParsedError(error);
+        notification.error(errorMessage);
+      }
+    };
+
+    const { signTypedDataAsync, isPending: isSigning } = useSignTypedData();
+    const router = useRouter();
+
+    const { mutateAsync: postNewStage, isPending: isPostingNewStage } = useMutation({
+      mutationFn: (newStageBody: CreateNewLargeStageReqBody) =>
+        postMutationFetcher("/api/large-stages/new", { body: newStageBody }),
+    });
+
+    const handleFeedbackModalClose = () => {
+      feedbackModalRef.current?.close();
+      router.refresh();
+    };
+
+    const { fields, append, remove } = useFieldArray({
+      control,
+      name: "milestones",
+    });
+
+    const watchMilestones = watch("milestones");
+    const totalAmount = watchMilestones.reduce((acc, curr) => acc + Number(curr.amount), 0);
+
+    return (
+      <>
+        <dialog id="action_modal" className="modal" ref={ref}>
+          <div className="modal-box flex flex-col space-y-3">
+            <form method="dialog" className="bg-secondary -mx-6 -mt-6 px-6 py-4 flex items-center justify-between">
+              <div className="flex justify-between items-center">
+                <p className="font-bold text-xl m-0">Stage {previousStage.stageNumber + 1} application</p>
+              </div>
+              {/* if there is a button in form, it will close the modal */}
+              <button className="btn btn-sm btn-circle btn-ghost text-xl h-auto">✕</button>
+            </form>
+            <FormProvider {...formMethods}>
+              <form onSubmit={handleSubmit(onSubmit)} className="w-full flex flex-col">
+                <div className="mt-4">
+                  <h3 className="text-lg font-bold">Planned milestones for this stage:</h3>
+                  <div className="rounded-xl bg-light-purple p-4">
+                    {fields.map((field, index) => (
+                      <div key={field.id}>
+                        {index > 0 && <hr className="border-t border-white my-6" />}
+                        <h4 className="text-2xl font-bold">
+                          Milestone {index + 1}
+                          <button type="button" onClick={() => remove(index)} className="ml-2">
+                            <TrashIcon className="h-4 w-4" />
+                          </button>
+                        </h4>
+                        <FormTextarea
+                          label="Description"
+                          showMessageLength
+                          {...formMethods.register(`milestones.${index}.description`)}
+                          error={errors?.milestones?.[index]?.description?.message}
+                        />
+                        <FormTextarea
+                          label="Detail of Deliverables"
+                          showMessageLength
+                          {...formMethods.register(`milestones.${index}.proposedDeliverables`)}
+                          error={errors?.milestones?.[index]?.proposedDeliverables?.message}
+                        />
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-x-16 sm:gap-y-1">
+                          <FormInputNumber
+                            label="Budget (USDC)"
+                            {...formMethods.register(`milestones.${index}.amount`, {
+                              setValueAs: value => parseInt(value),
+                            })}
+                            error={errors?.milestones?.[index]?.amount?.message}
+                          />
+                          <FormInputDate
+                            label="Deadline"
+                            name={`milestones.${index}.proposedCompletionDate`}
+                            error={errors?.milestones?.[index]?.proposedCompletionDate?.message}
+                          />
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                  <div className="flex justify-between mt-1">
+                    <div className="pt-6">
+                      <label className="font-bold">
+                        Total requested funds:
+                        <span className="bg-light-purple ml-2 p-1 rounded">
+                          {isNaN(totalAmount) ? "-" : totalAmount.toLocaleString()} USDC
+                        </span>
+                      </label>
+                    </div>
+                    <Button
+                      type="button"
+                      onClick={() =>
+                        append({
+                          description: "",
+                          proposedDeliverables: "",
+                          amount: 0,
+                          proposedCompletionDate: new Date(),
+                        })
+                      }
+                      variant="purple-secondary"
+                      size="sm"
+                      className="mt-2 text-sm"
+                    >
+                      + Add Milestone
+                    </Button>
+                  </div>
+                </div>
+                <Button
+                  variant="primary"
+                  type="submit"
+                  disabled={isPostingNewStage || isSigning}
+                  className="self-center mt-4"
+                >
+                  {(isPostingNewStage || isSigning) && <span className="loading loading-spinner"></span>}
+                  Apply
+                </Button>
+              </form>
+            </FormProvider>
+          </div>
+          <Toaster />
+        </dialog>
+
+        <dialog ref={feedbackModalRef} className="modal">
+          <div className="modal-box flex flex-col space-y-3">
+            <form method="dialog" className="bg-secondary -mx-6 -mt-6 px-6 py-4">
+              <div className="flex items-center">
+                <p className="font-bold text-xl m-0 text-center w-full">Stage Application Submitted!</p>
+              </div>
+            </form>
+
+            <div className="text-center">
+              <p>
+                Your stage application will be reviewed. You will receive information if we need more details, if the
+                application was rejected and why, or when it is approved.
+              </p>
+              <div className="mt-6 flex justify-center">
+                <Button onClick={handleFeedbackModalClose}>Accept</Button>
+              </div>
+            </div>
+          </div>
+          <Toaster />
+        </dialog>
+      </>
+    );
+  },
+);
+
+NewStageModal.displayName = "NewStageModal";

--- a/packages/nextjs/app/large-grants/[grantId]/_components/CurrentStage/NewStageModal/index.tsx
+++ b/packages/nextjs/app/large-grants/[grantId]/_components/CurrentStage/NewStageModal/index.tsx
@@ -105,12 +105,13 @@ export const NewStageModal = forwardRef<HTMLDialogElement, NewStageModalProps>(
                     {fields.map((field, index) => (
                       <div key={field.id}>
                         {index > 0 && <hr className="border-t border-white my-6" />}
-                        <h4 className="text-2xl font-bold">
-                          Milestone {index + 1}
-                          <button type="button" onClick={() => remove(index)} className="ml-2">
+                        <div className="flex items-center justify-between mb-4">
+                          <h4 className="text-2xl font-bold">Milestone {index + 1}</h4>
+                          <Button variant="secondary" size="sm" onClick={() => remove(index)} className="ml-2">
                             <TrashIcon className="h-4 w-4" />
-                          </button>
-                        </h4>
+                            <span className="hidden sm:inline">Delete milestone</span>
+                          </Button>
+                        </div>
                         <FormTextarea
                           label="Description"
                           showMessageLength

--- a/packages/nextjs/app/large-grants/[grantId]/_components/CurrentStage/NewStageModal/schema.tsx
+++ b/packages/nextjs/app/large-grants/[grantId]/_components/CurrentStage/NewStageModal/schema.tsx
@@ -1,0 +1,8 @@
+import * as z from "zod";
+import { milestoneSchema } from "~~/app/large-grant-apply/schema";
+
+export const newStageModalFormSchema = z.object({
+  milestones: z.array(milestoneSchema),
+});
+
+export type NewStageModalFormValues = z.infer<typeof newStageModalFormSchema>;

--- a/packages/nextjs/app/large-grants/[grantId]/_components/CurrentStage/index.tsx
+++ b/packages/nextjs/app/large-grants/[grantId]/_components/CurrentStage/index.tsx
@@ -1,7 +1,10 @@
 "use client";
 
+import { useRef } from "react";
 import { MilestoneDetail } from "./MilestoneDetail";
+import { NewStageModal } from "./NewStageModal";
 import { Badge } from "~~/components/pg-ens/Badge";
+import { Button } from "~~/components/pg-ens/Button";
 import { GrantProgressBar } from "~~/components/pg-ens/GrantProgressBar";
 import { LargeStageWithMilestones } from "~~/services/database/repositories/large-stages";
 
@@ -10,6 +13,8 @@ export const CurrentStage = ({ stage }: { stage: LargeStageWithMilestones }) => 
 
   const completedMilestones = stage.milestones.filter(milestone => milestone.status === "paid");
   const completedMilestonesAmount = completedMilestones.reduce((acc, current) => acc + current.amount, 0);
+
+  const newStageModalRef = useRef<HTMLDialogElement>(null);
 
   return (
     <div className="w-full max-w-5xl">
@@ -27,12 +32,32 @@ export const CurrentStage = ({ stage }: { stage: LargeStageWithMilestones }) => 
             amount={allMilestonesGrantAmount}
             withdrawn={completedMilestonesAmount}
           />
+
+          {stage.status === "completed" && (
+            <div className="flex justify-end">
+              <Button
+                variant="secondary"
+                size="sm"
+                className="mt-4"
+                onClick={() => newStageModalRef && newStageModalRef.current?.showModal()}
+              >
+                Apply for a new stage
+              </Button>
+            </div>
+          )}
         </div>
       )}
 
       {stage.milestones.map(milestone => (
         <MilestoneDetail milestone={milestone} key={milestone.id} />
       ))}
+
+      <NewStageModal
+        ref={newStageModalRef}
+        previousStage={stage}
+        grantId={stage.grantId}
+        closeModal={() => newStageModalRef.current?.close()}
+      />
     </div>
   );
 };

--- a/packages/nextjs/app/large-grants/[grantId]/_components/ProjectTimeline/TimelineStage.tsx
+++ b/packages/nextjs/app/large-grants/[grantId]/_components/ProjectTimeline/TimelineStage.tsx
@@ -1,5 +1,7 @@
+import { ExclamationCircleIcon } from "@heroicons/react/20/solid";
 import { ChatBubbleOvalLeftEllipsisIcon } from "@heroicons/react/24/outline";
 import { CheckCircleIcon as CheckCircleSolidIcon } from "@heroicons/react/24/solid";
+import { statusText } from "~~/components/pg-ens/BadgeMilestone";
 import { StyledTooltip } from "~~/components/pg-ens/StyledTooltip";
 import { LargeStageWithMilestones } from "~~/services/database/repositories/large-stages";
 import { getFormattedDate } from "~~/utils/getFormattedDate";
@@ -48,15 +50,22 @@ export const TimelineStage = ({ stage }: { stage: LargeStageWithMilestones }) =>
                   <div>
                     <div className={`text-lg font-bold flex ${isOdd ? "" : "sm:place-content-end"}`}>
                       Milestone {idx + 1} ({milestone.amount.toLocaleString()} USDC)
-                      {(milestone.status === "completed" || milestone.status === "paid") && (
+                      {["completed", "verified", "paid"].includes(milestone.status) && (
                         <CheckCircleSolidIcon
                           className={`ml-1 mt-1 h-6 w-6 ${
-                            milestone.status === "paid" ? "text-green-500" : "text-orange-500"
+                            milestone.status === "paid" ? "text-primary-green" : "text-primary-orange"
                           }`}
+                          title={statusText[milestone.status]}
+                        />
+                      )}
+                      {milestone.status === "rejected" && (
+                        <ExclamationCircleIcon
+                          className="ml-1 mt-1 h-6 w-6 text-primary-red"
+                          title={statusText[milestone.status]}
                         />
                       )}
                     </div>
-                    <div className="text-sm font-bold">{milestone.description}</div>
+                    <div className="text-sm">{milestone.description}</div>
                   </div>
                 </div>
               ))}

--- a/packages/nextjs/components/pg-ens/BadgeMilestone.tsx
+++ b/packages/nextjs/components/pg-ens/BadgeMilestone.tsx
@@ -4,6 +4,7 @@ const badgeBgColor: Record<LargeMilestoneStatus, string> = {
   proposed: "bg-warning",
   rejected: "bg-error",
   completed: "bg-warning",
+  verified: "bg-warning",
   paid: "bg-success",
   approved: "bg-success",
 };
@@ -12,6 +13,7 @@ const badgeTextColor: Record<LargeMilestoneStatus, string> = {
   proposed: "text-primary-orange",
   rejected: "text-primary-red",
   completed: "text-primary-orange",
+  verified: "text-primary-orange",
   paid: "text-primary-green",
   approved: "text-primary-green",
 };
@@ -28,6 +30,7 @@ const statusText: Record<LargeMilestoneStatus, string> = {
   proposed: "Proposed",
   rejected: "Rejected",
   completed: "Completed (Pending Review)",
+  verified: "Completed (Verified)",
   paid: "Completed (Paid)",
   approved: "Approved",
 };

--- a/packages/nextjs/components/pg-ens/BadgeMilestone.tsx
+++ b/packages/nextjs/components/pg-ens/BadgeMilestone.tsx
@@ -26,7 +26,7 @@ type BadgeProps = {
   className?: string;
 };
 
-const statusText: Record<LargeMilestoneStatus, string> = {
+export const statusText: Record<LargeMilestoneStatus, string> = {
   proposed: "Proposed",
   rejected: "Rejected",
   completed: "Completed (Pending Review)",

--- a/packages/nextjs/components/pg-ens/BadgeMilestone.tsx
+++ b/packages/nextjs/components/pg-ens/BadgeMilestone.tsx
@@ -30,7 +30,7 @@ const statusText: Record<LargeMilestoneStatus, string> = {
   proposed: "Proposed",
   rejected: "Rejected",
   completed: "Completed (Pending Review)",
-  verified: "Completed (Verified)",
+  verified: "Completed (Pending Review)",
   paid: "Completed (Paid)",
   approved: "Approved",
 };

--- a/packages/nextjs/components/pg-ens/form-fields/FormInputDate.tsx
+++ b/packages/nextjs/components/pg-ens/form-fields/FormInputDate.tsx
@@ -25,6 +25,7 @@ export const FormInputDate = ({ error, label, name, required }: FormInputProps) 
         onChange={date => setValue(name, date)}
         className={`input input-bordered mt-1 w-full${error ? " input-error" : ""}`}
         disabledKeyboardNavigation
+        dateFormat="d MMM yyyy"
       />
       <FormErrorMessage error={error} />
     </div>

--- a/packages/nextjs/components/scaffold-eth/Address.tsx
+++ b/packages/nextjs/components/scaffold-eth/Address.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { CopyToClipboard } from "react-copy-to-clipboard";
 import { Address as AddressType, getAddress, isAddress } from "viem";
 import { hardhat } from "viem/chains";
 import { normalize } from "viem/ens";
@@ -121,20 +120,23 @@ export const Address = ({ address, disableAddressLink, format, size = "base" }: 
           aria-hidden="true"
         />
       ) : (
-        <CopyToClipboard
-          text={checkSumAddress}
-          onCopy={() => {
-            setAddressCopied(true);
-            setTimeout(() => {
-              setAddressCopied(false);
-            }, 800);
+        <DocumentDuplicateIcon
+          className="ml-1.5 text-xl font-normal text-sky-600 h-5 w-5 cursor-pointer"
+          aria-hidden="true"
+          onClick={async () => {
+            if (checkSumAddress) {
+              try {
+                await navigator.clipboard.writeText(checkSumAddress);
+                setAddressCopied(true);
+                setTimeout(() => {
+                  setAddressCopied(false);
+                }, 800);
+              } catch (err) {
+                console.error("Failed to copy address to clipboard:", err);
+              }
+            }
           }}
-        >
-          <DocumentDuplicateIcon
-            className="ml-1.5 text-xl font-normal text-sky-600 h-5 w-5 cursor-pointer"
-            aria-hidden="true"
-          />
-        </CopyToClipboard>
+        />
       )}
     </div>
   );

--- a/packages/nextjs/hooks/pg-ens/useLargeMilestoneReview.ts
+++ b/packages/nextjs/hooks/pg-ens/useLargeMilestoneReview.ts
@@ -1,0 +1,91 @@
+import { useRouter } from "next/navigation";
+import { useMutation } from "@tanstack/react-query";
+import { useAccount, useSignTypedData } from "wagmi";
+import { ReviewMilestoneBody } from "~~/app/api/large-milestones/[milestoneId]/review/route";
+import { LargeMilestoneStatus } from "~~/services/database/repositories/large-milestones";
+import { EIP_712_DOMAIN, EIP_712_TYPES__REVIEW_LARGE_MILESTONE } from "~~/utils/eip712";
+import { postMutationFetcher } from "~~/utils/react-query";
+import { getParsedError, notification } from "~~/utils/scaffold-eth";
+
+export const useLargeMilestoneReview = (milestoneId?: number) => {
+  const router = useRouter();
+  const { signTypedDataAsync, isPending: isSigning } = useSignTypedData();
+  const { address: connectedAddress } = useAccount();
+
+  const { mutateAsync: postMilestoneReview, isPending: isPostingMilestoneReview } = useMutation({
+    mutationFn: (reviewedMilestone: ReviewMilestoneBody) =>
+      postMutationFetcher(`/api/large-milestones/${milestoneId}/review`, { body: reviewedMilestone }),
+  });
+
+  const reviewMilestone = async ({
+    status,
+    txHash,
+    statusNote,
+  }: {
+    status: LargeMilestoneStatus;
+    txHash?: string;
+    statusNote?: string;
+  }) => {
+    if (!milestoneId) return;
+    let notificationId;
+    try {
+      if (!connectedAddress) {
+        notification.error("Please connect your wallet");
+        return;
+      }
+
+      if ((status === "verified" || status === "completed") && !txHash) {
+        notification.error("Please fill tx hash");
+        return;
+      }
+
+      const signature = await signTypedDataAsync({
+        domain: EIP_712_DOMAIN,
+        types: EIP_712_TYPES__REVIEW_LARGE_MILESTONE,
+        primaryType: "Message",
+        message: {
+          milestoneId: milestoneId.toString(),
+          action: status,
+          txHash: txHash || "",
+          statusNote: statusNote || "",
+        },
+      });
+
+      const verifiedObj =
+        status === "verified"
+          ? {
+              verifiedTx: txHash,
+            }
+          : {};
+
+      const paymentObj =
+        status === "paid"
+          ? {
+              paymentTx: txHash,
+            }
+          : {};
+
+      notificationId = notification.loading("Submitting review");
+      await postMilestoneReview({
+        status,
+        signature,
+        statusNote,
+        ...verifiedObj,
+        ...paymentObj,
+      });
+      notification.remove(notificationId);
+      notification.success(`Milestone ${status}`);
+      router.refresh();
+    } catch (error) {
+      if (notificationId) notification.remove(notificationId);
+      const errorMessage = getParsedError(error);
+      notification.error(errorMessage);
+    }
+  };
+
+  return {
+    reviewMilestone,
+    isSigning,
+    isPostingMilestoneReview,
+  };
+};

--- a/packages/nextjs/hooks/pg-ens/useLargeMilestoneReview.ts
+++ b/packages/nextjs/hooks/pg-ens/useLargeMilestoneReview.ts
@@ -21,10 +21,12 @@ export const useLargeMilestoneReview = (milestoneId?: number) => {
     status,
     txHash,
     statusNote,
+    completionProof,
   }: {
     status: LargeMilestoneStatus;
     txHash?: string;
     statusNote?: string;
+    completionProof?: string;
   }) => {
     if (!milestoneId) return;
     let notificationId;
@@ -34,7 +36,7 @@ export const useLargeMilestoneReview = (milestoneId?: number) => {
         return;
       }
 
-      if ((status === "verified" || status === "completed") && !txHash) {
+      if ((status === "verified" || status === "paid") && !txHash) {
         notification.error("Please fill tx hash");
         return;
       }
@@ -65,11 +67,12 @@ export const useLargeMilestoneReview = (milestoneId?: number) => {
             }
           : {};
 
-      notificationId = notification.loading("Submitting review");
+      notificationId = notification.loading("Submitting milestone");
       await postMilestoneReview({
         status,
         signature,
         statusNote,
+        completionProof,
         ...verifiedObj,
         ...paymentObj,
       });

--- a/packages/nextjs/hooks/pg-ens/useLargeStageReview.ts
+++ b/packages/nextjs/hooks/pg-ens/useLargeStageReview.ts
@@ -1,0 +1,76 @@
+import { useRouter } from "next/navigation";
+import { useMutation } from "@tanstack/react-query";
+import { useAccount, useSignTypedData } from "wagmi";
+import { ReviewStageBody } from "~~/app/api/stages/[stageId]/review/route";
+import { Status } from "~~/services/database/repositories/stages";
+import { EIP_712_DOMAIN, EIP_712_TYPES__REVIEW_LARGE_STAGE } from "~~/utils/eip712";
+import { postMutationFetcher } from "~~/utils/react-query";
+import { getParsedError, notification } from "~~/utils/scaffold-eth";
+
+export const useLargeStageReview = (stageId?: number) => {
+  const router = useRouter();
+  const { signTypedDataAsync, isPending: isSigning } = useSignTypedData();
+  const { address: connectedAddress } = useAccount();
+
+  const { mutateAsync: postStageReview, isPending: isPostingStageReview } = useMutation({
+    mutationFn: (reviewedStage: ReviewStageBody) =>
+      postMutationFetcher(`/api/large-stages/${stageId}/review`, { body: reviewedStage }),
+  });
+
+  const reviewStage = async ({
+    status,
+    txHash,
+    statusNote,
+  }: {
+    status: Status;
+    txHash?: string;
+    statusNote?: string;
+  }) => {
+    if (!stageId) return;
+    let notificationId;
+    try {
+      if (!connectedAddress) {
+        notification.error("Please connect your wallet");
+        return;
+      }
+
+      if (status === "approved" && !txHash) {
+        notification.error("Please fill tx hash");
+        return;
+      }
+
+      const signature = await signTypedDataAsync({
+        domain: EIP_712_DOMAIN,
+        types: EIP_712_TYPES__REVIEW_LARGE_STAGE,
+        primaryType: "Message",
+        message: {
+          stageId: stageId.toString(),
+          action: status,
+          txHash: txHash || "",
+          statusNote: statusNote || "",
+        },
+      });
+
+      notificationId = notification.loading("Submitting review");
+      await postStageReview({
+        status,
+        approvedTx: txHash,
+        signature,
+        statusNote,
+      });
+      notification.remove(notificationId);
+      notification.success(`Grant ${status}`);
+      router.refresh();
+    } catch (error) {
+      if (notificationId) notification.remove(notificationId);
+      const errorMessage = getParsedError(error);
+      notification.error(errorMessage);
+    }
+  };
+
+  return {
+    reviewStage,
+    isSigning,
+    isPostingStageReview,
+  };
+};

--- a/packages/nextjs/services/database/config/schema.ts
+++ b/packages/nextjs/services/database/config/schema.ts
@@ -139,6 +139,7 @@ export const milestonesStatusEnum = pgEnum("milestones_status", [
   "proposed",
   "approved",
   "completed",
+  "verified",
   "paid",
   "rejected",
 ]);
@@ -156,22 +157,26 @@ export const largeMilestones = pgTable("large_milestones", {
   amount: integer("amount").notNull(),
   status: milestonesStatusEnum("status").notNull().default("proposed"),
   statusNote: text("statusNote"),
+  verifiedTx: varchar("verified_tx", { length: 66 }),
+  verifiedAt: timestamp("verified_at"),
+  verifiedBy: varchar("verified_by", { length: 42 }),
   paymentTx: varchar("payment_tx", { length: 66 }),
   paidAt: timestamp("paid_at"),
+  paidBy: varchar("paid_by", { length: 42 }),
 });
 
-export const largeMilestonesRelations = relations(largeMilestones, ({ one }) => ({
+export const largeMilestonesRelations = relations(largeMilestones, ({ one, many }) => ({
   stage: one(largeStages, {
     fields: [largeMilestones.stageId],
     references: [largeStages.id],
   }),
+  privateNotes: many(largeMilestonePrivateNotes),
 }));
 
 export const largeApprovalVotes = pgTable(
   "large_approval_votes",
   {
     id: serial("id").primaryKey(),
-    amount: bigint("amount", { mode: "bigint" }).notNull(),
     votedAt: timestamp("voted_at").default(sql`now()`),
     stageId: integer("stage_id")
       .references(() => largeStages.id)
@@ -209,6 +214,25 @@ export const largePrivateNotesRelations = relations(largePrivateNotes, ({ one })
   stage: one(largeStages, {
     fields: [largePrivateNotes.stageId],
     references: [largeStages.id],
+  }),
+}));
+
+export const largeMilestonePrivateNotes = pgTable("large_milestone_private_notes", {
+  id: serial("id").primaryKey(),
+  note: text("note").notNull(),
+  writtenAt: timestamp("written_at").default(sql`now()`),
+  milestoneId: integer("milestone_id")
+    .references(() => largeMilestones.id)
+    .notNull(),
+  authorAddress: varchar("author_address", { length: 42 })
+    .references(() => users.address)
+    .notNull(),
+});
+
+export const largeMilestonePrivateNotesRelations = relations(largeMilestonePrivateNotes, ({ one }) => ({
+  milestone: one(largeMilestones, {
+    fields: [largeMilestonePrivateNotes.milestoneId],
+    references: [largeMilestones.id],
   }),
 }));
 

--- a/packages/nextjs/services/database/config/schema.ts
+++ b/packages/nextjs/services/database/config/schema.ts
@@ -198,6 +198,31 @@ export const largeApprovalVotesRelations = relations(largeApprovalVotes, ({ one 
   }),
 }));
 
+export const largeRejectVotes = pgTable(
+  "large_reject_votes",
+  {
+    id: serial("id").primaryKey(),
+    votedAt: timestamp("voted_at").default(sql`now()`),
+    stageId: integer("stage_id")
+      .references(() => largeStages.id)
+      .notNull(),
+    authorAddress: varchar("author_address", { length: 42 })
+      .references(() => users.address)
+      .notNull(),
+  },
+  table => ({
+    // Ensure each author can only vote once per stage
+    uniqueVotePerStage: unique().on(table.stageId, table.authorAddress),
+  }),
+);
+
+export const largeRejectVotesRelations = relations(largeRejectVotes, ({ one }) => ({
+  stage: one(largeStages, {
+    fields: [largeRejectVotes.stageId],
+    references: [largeStages.id],
+  }),
+}));
+
 export const largePrivateNotes = pgTable("large_private_notes", {
   id: serial("id").primaryKey(),
   note: text("note").notNull(),
@@ -244,6 +269,7 @@ export const largeStagesRelations = relations(largeStages, ({ one, many }) => ({
   milestones: many(largeMilestones),
   privateNotes: many(largePrivateNotes),
   approvalVotes: many(largeApprovalVotes),
+  rejectVotes: many(largeRejectVotes),
 }));
 
 export const userRoleEnum = pgEnum("user_role", ["admin", "grantee"]);

--- a/packages/nextjs/services/database/repositories/large-approval-votes.ts
+++ b/packages/nextjs/services/database/repositories/large-approval-votes.ts
@@ -1,0 +1,10 @@
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { db } from "~~/services/database/config/postgresClient";
+import { largeApprovalVotes } from "~~/services/database/config/schema";
+
+export type LargeApprovalVoteInsert = InferInsertModel<typeof largeApprovalVotes>;
+export type LargeApprovalVote = InferSelectModel<typeof largeApprovalVotes>;
+
+export async function createLargeApprovalVote(approvalVote: LargeApprovalVoteInsert) {
+  return await db.insert(largeApprovalVotes).values(approvalVote).returning({ id: largeApprovalVotes.id });
+}

--- a/packages/nextjs/services/database/repositories/large-grants.ts
+++ b/packages/nextjs/services/database/repositories/large-grants.ts
@@ -167,7 +167,7 @@ export async function getLargeGrantsStats() {
     orderBy: [desc(largeGrants.submitedAt)],
   });
 
-  const proposedLargeGrants = sortedLargeGrants.filter(grant => {
+  const approvedLargeGrants = sortedLargeGrants.filter(grant => {
     const latestStage = grant.stages[0];
     return (
       latestStage &&
@@ -179,7 +179,7 @@ export async function getLargeGrantsStats() {
   return {
     totalUsdcGranted: Number(usdcFromCompletedMilestones[0].total) || 0,
     allGrantsCount: Number(allLargeGrants[0].count) || 0,
-    proposedLargeGrants,
-    proposedLargeGrantsCount: proposedLargeGrants.length,
+    approvedLargeGrants,
+    approvedLargeGrantsCount: approvedLargeGrants.length,
   };
 }

--- a/packages/nextjs/services/database/repositories/large-grants.ts
+++ b/packages/nextjs/services/database/repositories/large-grants.ts
@@ -65,7 +65,6 @@ export async function getPublicLargeGrants() {
   });
 }
 
-// Note: not used yet
 // Note: use only for admin pages
 export async function getAllLargeGrantsWithStagesAndPrivateNotes() {
   return await db.query.largeGrants.findMany({
@@ -77,6 +76,9 @@ export async function getAllLargeGrantsWithStagesAndPrivateNotes() {
         with: {
           privateNotes: true,
           approvalVotes: true,
+          milestones: {
+            orderBy: [asc(largeMilestones.milestoneNumber)],
+          },
         },
       },
     },

--- a/packages/nextjs/services/database/repositories/large-grants.ts
+++ b/packages/nextjs/services/database/repositories/large-grants.ts
@@ -149,7 +149,7 @@ export async function getLargeGrantsStats() {
         total: sql`COALESCE(sum(${largeMilestones.amount}), 0)::float`,
       })
       .from(largeMilestones)
-      .where(eq(largeMilestones.status, "completed")),
+      .where(eq(largeMilestones.status, "paid")),
 
     db
       .select({

--- a/packages/nextjs/services/database/repositories/large-grants.ts
+++ b/packages/nextjs/services/database/repositories/large-grants.ts
@@ -76,6 +76,7 @@ export async function getAllLargeGrantsWithStagesAndPrivateNotes() {
         with: {
           privateNotes: true,
           approvalVotes: true,
+          rejectVotes: true,
           milestones: {
             orderBy: [asc(largeMilestones.milestoneNumber)],
           },

--- a/packages/nextjs/services/database/repositories/large-milestone-private-notes.ts
+++ b/packages/nextjs/services/database/repositories/large-milestone-private-notes.ts
@@ -1,0 +1,13 @@
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { db } from "~~/services/database/config/postgresClient";
+import { largeMilestonePrivateNotes } from "~~/services/database/config/schema";
+
+export type MilestonePrivateNoteInsert = InferInsertModel<typeof largeMilestonePrivateNotes>;
+export type MilestonePrivateNote = InferSelectModel<typeof largeMilestonePrivateNotes>;
+
+export async function createLargeMilestonePrivateNote(privateNote: MilestonePrivateNoteInsert) {
+  return await db
+    .insert(largeMilestonePrivateNotes)
+    .values(privateNote)
+    .returning({ id: largeMilestonePrivateNotes.id });
+}

--- a/packages/nextjs/services/database/repositories/large-milestones.ts
+++ b/packages/nextjs/services/database/repositories/large-milestones.ts
@@ -24,7 +24,7 @@ export async function updateMilestoneStatusToCompleted(milestoneId: number) {
   return await db.update(largeMilestones).set({ status: "completed" }).where(eq(largeMilestones.id, milestoneId));
 }
 
-export async function getCompledOrVerifiedMilestones() {
+export async function getCompletedOrVerifiedMilestones() {
   return await db.query.largeMilestones.findMany({
     where: or(eq(largeMilestones.status, "completed"), eq(largeMilestones.status, "verified")),
     orderBy: [desc(largeMilestones.completedAt)],

--- a/packages/nextjs/services/database/repositories/large-milestones.ts
+++ b/packages/nextjs/services/database/repositories/large-milestones.ts
@@ -1,4 +1,4 @@
-import { InferInsertModel, InferSelectModel, eq } from "drizzle-orm";
+import { InferInsertModel, InferSelectModel, desc, eq, or } from "drizzle-orm";
 import { db } from "~~/services/database/config/postgresClient";
 import { largeMilestones, milestonesStatusEnum } from "~~/services/database/config/schema";
 
@@ -12,7 +12,6 @@ export async function createMilestone(milestone: LargeMilestoneInsert) {
   return await db.insert(largeMilestones).values(milestone).returning({ id: largeMilestones.id });
 }
 
-// Note: not used yet
 export async function updateMilestone(
   milestoneId: Required<LargeMilestoneUpdate>["id"],
   milestone: LargeMilestoneUpdate,
@@ -23,4 +22,32 @@ export async function updateMilestone(
 // Note: not used yet
 export async function updateMilestoneStatusToCompleted(milestoneId: number) {
   return await db.update(largeMilestones).set({ status: "completed" }).where(eq(largeMilestones.id, milestoneId));
+}
+
+export async function getCompledOrVerifiedMilestones() {
+  return await db.query.largeMilestones.findMany({
+    where: or(eq(largeMilestones.status, "completed"), eq(largeMilestones.status, "verified")),
+    orderBy: [desc(largeMilestones.completedAt)],
+    with: {
+      stage: {
+        with: {
+          grant: true,
+        },
+      },
+      privateNotes: true,
+    },
+  });
+}
+
+export async function getMilestoneByIdWithRelatedData(milestoneId: number) {
+  return await db.query.largeMilestones.findFirst({
+    where: eq(largeMilestones.id, milestoneId),
+    with: {
+      stage: {
+        with: {
+          grant: true,
+        },
+      },
+    },
+  });
 }

--- a/packages/nextjs/services/database/repositories/large-private-notes.ts
+++ b/packages/nextjs/services/database/repositories/large-private-notes.ts
@@ -1,0 +1,10 @@
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { db } from "~~/services/database/config/postgresClient";
+import { largePrivateNotes } from "~~/services/database/config/schema";
+
+export type PrivateNoteInsert = InferInsertModel<typeof largePrivateNotes>;
+export type PrivateNote = InferSelectModel<typeof largePrivateNotes>;
+
+export async function createLargePrivateNote(privateNote: PrivateNoteInsert) {
+  return await db.insert(largePrivateNotes).values(privateNote).returning({ id: largePrivateNotes.id });
+}

--- a/packages/nextjs/services/database/repositories/large-reject-votes.ts
+++ b/packages/nextjs/services/database/repositories/large-reject-votes.ts
@@ -1,0 +1,10 @@
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { db } from "~~/services/database/config/postgresClient";
+import { largeRejectVotes } from "~~/services/database/config/schema";
+
+export type LargeRejectVoteInsert = InferInsertModel<typeof largeRejectVotes>;
+export type LargeRejectVote = InferSelectModel<typeof largeRejectVotes>;
+
+export async function createLargeRejectVote(rejectVote: LargeRejectVoteInsert) {
+  return await db.insert(largeRejectVotes).values(rejectVote).returning({ id: largeRejectVotes.id });
+}

--- a/packages/nextjs/services/database/repositories/large-stages.ts
+++ b/packages/nextjs/services/database/repositories/large-stages.ts
@@ -63,6 +63,7 @@ export async function getStageByIdWithGrantAndVotes(stageId: number) {
     with: {
       grant: true,
       approvalVotes: true,
+      rejectVotes: true,
     },
   });
 }

--- a/packages/nextjs/services/database/repositories/large-stages.ts
+++ b/packages/nextjs/services/database/repositories/large-stages.ts
@@ -43,7 +43,15 @@ export async function getStageByIdWithGrantAndVotes(stageId: number) {
   });
 }
 
-// Note: not used yet
+export async function getStageWithMilestones(stageId: number) {
+  return await db.query.largeStages.findFirst({
+    where: eq(largeStages.id, stageId),
+    with: {
+      milestones: true,
+    },
+  });
+}
+
 export async function updateStageStatusToCompleted(stageId: number) {
   return await db.update(largeStages).set({ status: "completed" }).where(eq(largeStages.id, stageId));
 }

--- a/packages/nextjs/services/database/seed.ts
+++ b/packages/nextjs/services/database/seed.ts
@@ -3,6 +3,7 @@ import {
   grants,
   largeApprovalVotes,
   largeGrants,
+  largeMilestonePrivateNotes,
   largeMilestones,
   largePrivateNotes,
   largeStages,
@@ -33,6 +34,7 @@ async function seed() {
   await db.delete(stages).execute(); // Ensure stages are deleted before grants
   await db.delete(grants).execute(); // Delete grants
 
+  await db.delete(largeMilestonePrivateNotes).execute();
   await db.delete(largeMilestones).execute();
   await db.delete(largePrivateNotes).execute();
   await db.delete(largeApprovalVotes).execute();
@@ -163,6 +165,16 @@ async function seed() {
         telegram: "telegram-account-3",
         email: "email3@email.com",
       },
+      {
+        title: "Large Grant 4",
+        description: "Description for grant 4",
+        builderAddress: "0xB4F53bd85c00EF22946d24Ae26BC38Ac64F5E7B1",
+        showcaseVideoUrl: null,
+        github: "github-account-4",
+        twitter: null,
+        telegram: "telegram-account-4",
+        email: "email3@email.com",
+      },
     ])
     .returning({ id: largeGrants.id })
     .execute();
@@ -202,6 +214,10 @@ async function seed() {
       {
         stageNumber: 3,
         grantId: insertedLargeGrants[2].id,
+      },
+      {
+        stageNumber: 1,
+        grantId: insertedLargeGrants[3].id,
       },
     ])
     .returning({ id: largeStages.id })
@@ -330,6 +346,24 @@ async function seed() {
         amount: 40,
         proposedDeliverables: "Deliverables 9",
         proposedCompletionDate: new Date("2025-09-01"),
+      },
+      {
+        description: "Milestone 1 - Stage 1 - Large Grant 4",
+        milestoneNumber: 1,
+        stageId: insertedLargeStages[7].id,
+        status: "proposed",
+        amount: 4000,
+        proposedDeliverables: "Deliverables 10",
+        proposedCompletionDate: new Date("2025-10-01"),
+      },
+      {
+        description: "Milestone 2 - Stage 1 - Large Grant 4",
+        milestoneNumber: 2,
+        stageId: insertedLargeStages[7].id,
+        status: "proposed",
+        amount: 2000,
+        proposedDeliverables: "Deliverables 11",
+        proposedCompletionDate: new Date("2025-11-01"),
       },
     ])
     .execute();

--- a/packages/nextjs/services/database/seed.ts
+++ b/packages/nextjs/services/database/seed.ts
@@ -6,6 +6,7 @@ import {
   largeMilestonePrivateNotes,
   largeMilestones,
   largePrivateNotes,
+  largeRejectVotes,
   largeStages,
   privateNotes,
   stages,
@@ -38,6 +39,7 @@ async function seed() {
   await db.delete(largeMilestones).execute();
   await db.delete(largePrivateNotes).execute();
   await db.delete(largeApprovalVotes).execute();
+  await db.delete(largeRejectVotes).execute();
   await db.delete(largeStages).execute();
   await db.delete(largeGrants).execute();
 

--- a/packages/nextjs/services/notifications/telegram.ts
+++ b/packages/nextjs/services/notifications/telegram.ts
@@ -1,5 +1,6 @@
 import { CreateNewGrantReqBody } from "~~/app/api/grants/new/route";
 import { CreateNewLargeGrantReqBody } from "~~/app/api/large-grants/new/route";
+import { CreateNewLargeStageReqBody } from "~~/app/api/large-stages/new/route";
 import { CreateNewStageReqBody } from "~~/app/api/stages/new/route";
 import { GrantWithStages } from "~~/app/grants/[grantId]/page";
 
@@ -7,7 +8,8 @@ const TELEGRAM_BOT_URL = process.env.TELEGRAM_BOT_URL;
 const TELEGRAM_WEBHOOK_SECRET = process.env.TELEGRAM_WEBHOOK_SECRET;
 
 type StageData = {
-  newStage: CreateNewStageReqBody;
+  newStage?: CreateNewStageReqBody;
+  newLargeStage?: CreateNewLargeStageReqBody;
   grant?: GrantWithStages;
   largeGrant?: CreateNewLargeGrantReqBody;
 };
@@ -15,7 +17,7 @@ type StageData = {
 type GrantData = CreateNewGrantReqBody & { builderAddress: string };
 type LargeGrantData = CreateNewLargeGrantReqBody & { builderAddress: string };
 
-export async function notifyTelegramBot<T extends "grant" | "stage" | "largeGrant">(
+export async function notifyTelegramBot<T extends "grant" | "stage" | "largeGrant" | "largeStage">(
   endpoint: T,
   data: T extends "grant" ? GrantData : T extends "largeGrant" ? LargeGrantData : StageData,
 ) {

--- a/packages/nextjs/types/utils.ts
+++ b/packages/nextjs/types/utils.ts
@@ -1,7 +1,13 @@
-import { PublicGrant, getAllGrants, getBuilderGrants } from "~~/services/database/repositories/grants";
+import {
+  PublicGrant,
+  getAllGrants,
+  getAllGrantsWithStagesAndPrivateNotes,
+  getBuilderGrants,
+} from "~~/services/database/repositories/grants";
 import {
   PublicLargeGrant,
   getAllLargeGrants,
+  getAllLargeGrantsWithStagesAndPrivateNotes,
   getBuilderLargeGrants,
 } from "~~/services/database/repositories/large-grants";
 
@@ -27,3 +33,13 @@ export type AdminLargeGrant = Awaited<ReturnType<typeof getAllLargeGrants>>[0];
 
 // Add a discriminator property to distinguish between Grant and LargeGrant
 export type DiscriminatedAdminGrant = (AdminGrant & { type: "grant" }) | (AdminLargeGrant & { type: "largeGrant" });
+
+export type GrantWithStagesAndPrivateNotes = Awaited<ReturnType<typeof getAllGrantsWithStagesAndPrivateNotes>>[0];
+
+export type LargeGrantWithStagesAndPrivateNotes = Awaited<
+  ReturnType<typeof getAllLargeGrantsWithStagesAndPrivateNotes>
+>[0];
+
+export type DiscriminatedGrantWithStagesAndPrivateNotes =
+  | (GrantWithStagesAndPrivateNotes & { type: "grant" })
+  | (LargeGrantWithStagesAndPrivateNotes & { type: "largeGrant" });

--- a/packages/nextjs/utils/eip712.ts
+++ b/packages/nextjs/utils/eip712.ts
@@ -39,3 +39,32 @@ export const EIP_712_TYPES__STAGE_APPROVAL_VOTE = {
     { name: "stageId", type: "string" },
   ],
 } as const;
+
+export const EIP_712_TYPES__LARGE_STAGE_APPROVAL_VOTE = {
+  Message: [{ name: "stageId", type: "string" }],
+} as const;
+
+export const EIP_712_TYPES__REVIEW_LARGE_STAGE = {
+  Message: [
+    { name: "stageId", type: "string" },
+    { name: "action", type: "string" },
+    { name: "txHash", type: "string" },
+    { name: "statusNote", type: "string" },
+  ],
+} as const;
+
+export const EIP_712_TYPES__LARGE_MILESTONE_PRIVATE_NOTE = {
+  Message: [
+    { name: "milestoneId", type: "string" },
+    { name: "note", type: "string" },
+  ],
+} as const;
+
+export const EIP_712_TYPES__REVIEW_LARGE_MILESTONE = {
+  Message: [
+    { name: "milestoneId", type: "string" },
+    { name: "action", type: "string" },
+    { name: "txHash", type: "string" },
+    { name: "statusNote", type: "string" },
+  ],
+} as const;

--- a/packages/nextjs/utils/eip712.ts
+++ b/packages/nextjs/utils/eip712.ts
@@ -44,6 +44,13 @@ export const EIP_712_TYPES__LARGE_STAGE_APPROVAL_VOTE = {
   Message: [{ name: "stageId", type: "string" }],
 } as const;
 
+export const EIP_712_TYPES__LARGE_STAGE_REJECT_VOTE = {
+  Message: [
+    { name: "stageId", type: "string" },
+    { name: "statusNote", type: "string" },
+  ],
+} as const;
+
 export const EIP_712_TYPES__REVIEW_LARGE_STAGE = {
   Message: [
     { name: "stageId", type: "string" },

--- a/packages/nextjs/utils/eip712.ts
+++ b/packages/nextjs/utils/eip712.ts
@@ -68,3 +68,10 @@ export const EIP_712_TYPES__REVIEW_LARGE_MILESTONE = {
     { name: "statusNote", type: "string" },
   ],
 } as const;
+
+export const EIP_712_TYPES__APPLY_FOR_LARGE_STAGE = {
+  Message: [
+    { name: "stage_number", type: "string" },
+    { name: "milestones", type: "string" },
+  ],
+} as const;

--- a/packages/nextjs/utils/getFormattedDate.ts
+++ b/packages/nextjs/utils/getFormattedDate.ts
@@ -1,8 +1,24 @@
-export function getFormattedDate(date: Date) {
-  const monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+const monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
+export function getFormattedDate(date: Date) {
   const month = monthNames[date.getMonth()];
-  const year = date.getFullYear().toString().slice(-2);
+  const year = date.getFullYear().toString();
 
   return `${month} ${year}`;
+}
+
+export function getFormattedDateWithDay(date: Date) {
+  const dateFormatted = getFormattedDate(date);
+
+  const day = date.getDate().toString();
+
+  return `${day} ${dateFormatted}`;
+}
+
+export function getFormattedDeadline(date: Date) {
+  const month = monthNames[date.getUTCMonth()];
+  const year = date.getUTCFullYear().toString();
+  const day = date.getUTCDate().toString();
+
+  return `${day} ${month} ${year}`;
 }


### PR DESCRIPTION
- Added USDC grants to **New Grant Proposals** and **New Stage Proposals**
- The USDC grants and new stages can be rejected, approved, and final approved, almost like the current ETH grants. Stewards can attach private notes, too.
- Added new column for **Milestones to Review**
- Added new status **Verified** to USDC grant milestones. This is when the milestone is completed and one Steward has verified (approved) it.
- The milestones can be rejected or approved. The approve feature approves the milestone at the contract level. And the second approval, complete the milestone, and send the funds.
- Private notes can be attached to a milestone, too.
- The flow expects stewards to use the app to create grants and approve milestones. We should think if we need to listen for contract events too.
- There is some duplicated code between ETH and USDC grants. I only tried to unify when the code was almost the same. If not, I preferred to duplicate the component to avoid issues with the current ETH grants.
- To be able to test, load the seed data, connect an admin account, and go to /admin.

![localhost_3000_admin (5)](https://github.com/user-attachments/assets/1b8f0079-8b5e-4f14-8410-64ab9b1c40a5)

closes #27 