### PR TITLE
Confirmation dialog for large grants approvals

### DIFF
--- a/packages/nextjs/app/admin/_components/LargeGrantApprovalVoteModal/index.tsx
+++ b/packages/nextjs/app/admin/_components/LargeGrantApprovalVoteModal/index.tsx
@@ -49,29 +49,39 @@ export const LargeGrantApprovalVoteModal = forwardRef<HTMLDialogElement, Approva
 
     return (
       <dialog id="action_modal" className="modal" ref={ref}>
-        <div className="modal-box flex flex-col space-y-3">
+        <div className="modal-box flex flex-col space-y-6">
           <form method="dialog" className="bg-secondary -mx-6 -mt-6 px-6 py-4 flex items-center justify-between">
             <div className="flex justify-between items-center">
               <p className="font-bold text-xl m-0">
-                Approval vote for Stage {stage.stageNumber} of {grantName}
+                {stage.stageNumber > 1 ? `Stage ${stage.stageNumber} of ${grantName}` : grantName}
               </p>
             </div>
             {/* if there is a button in form, it will close the modal */}
             <button className="btn btn-sm btn-circle btn-ghost text-xl h-auto">✕</button>
           </form>
-          <span className="text-sm">
-            <p>This grant doesn&apos;t meet the approval threshold to setup contract yet.</p>
-          </span>
-          <Button
-            type="submit"
-            variant="green-secondary"
-            disabled={isPostingApprovalVote || isSigning}
-            className="self-center"
-            onClick={onSubmit}
-          >
-            {(isPostingApprovalVote || isSigning) && <span className="loading loading-spinner"></span>}
-            Vote for approval
-          </Button>
+          <div>Are you sure you want to vote for the approval of this {stage.stageNumber > 1 ? "stage" : "grant"}?</div>
+          <div className="flex justify-between">
+            <Button
+              variant="secondary"
+              size="sm"
+              disabled={isPostingApprovalVote || isSigning}
+              className="self-center"
+              onClick={closeModal}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="green-secondary"
+              size="sm"
+              disabled={isPostingApprovalVote || isSigning}
+              className="self-center"
+              onClick={onSubmit}
+            >
+              {(isPostingApprovalVote || isSigning) && <span className="loading loading-spinner"></span>}
+              Vote for approval
+            </Button>
+          </div>
         </div>
         <Toaster />
       </dialog>

--- a/packages/nextjs/app/admin/_components/LargeMilestoneApprovalModal/index.tsx
+++ b/packages/nextjs/app/admin/_components/LargeMilestoneApprovalModal/index.tsx
@@ -125,7 +125,7 @@ export const LargeMilestoneApprovalModal = forwardRef<
 
   return (
     <dialog id="action_modal" className="modal" ref={ref}>
-      <div className="modal-box flex flex-col space-y-3">
+      <div className="modal-box flex flex-col space-y-6">
         <form method="dialog" className="bg-secondary -mx-6 -mt-6 px-6 py-4 flex items-center justify-between">
           <div className="flex justify-between items-center">
             <p className="font-bold text-xl m-0">
@@ -145,9 +145,11 @@ export const LargeMilestoneApprovalModal = forwardRef<
               <div className="divider" />
             </>
           )}
-          <form onSubmit={handleSubmit(onSubmit)} className="w-full flex flex-col gap-1">
-            {milestone.status === "verified" && (
+          <form onSubmit={handleSubmit(onSubmit)} className="w-full flex flex-col gap-1 space-y-6">
+            {milestone.status === "verified" ? (
               <FormTextarea label="Note (visible to grantee)" {...getCommonOptions("statusNote")} />
+            ) : (
+              <div>Are you sure you want to vote for the approval of this milestone?</div>
             )}
             {loadingStatusText && (
               <div className="text-xl flex justify-center items-center gap-2 my-2">
@@ -155,9 +157,20 @@ export const LargeMilestoneApprovalModal = forwardRef<
                 {loadingStatusText}
               </div>
             )}
-            <Button variant="green" type="submit" className="!px-4 self-center" disabled={Boolean(loadingStatus)}>
-              <span>{milestone.status === "verified" ? "Final Approve" : "Approve"}</span>
-            </Button>
+            <div className="flex justify-between">
+              <Button
+                variant="secondary"
+                size="sm"
+                disabled={Boolean(loadingStatus)}
+                className="self-center"
+                onClick={closeModal}
+              >
+                Cancel
+              </Button>
+              <Button variant="green" type="submit" className="!px-4 self-center" disabled={Boolean(loadingStatus)}>
+                <span>{milestone.status === "verified" ? "Final Approve" : "Approve"}</span>
+              </Button>
+            </div>
           </form>
         </FormProvider>
       </div>


### PR DESCRIPTION
USDC grant approval:

![localhost_3000_large-grant-apply (2)](https://github.com/user-attachments/assets/af68bdf2-fbdf-4f6b-b318-3bd60634c12b)

USDC new stage approval:

![localhost_3000_large-grant-apply (3)](https://github.com/user-attachments/assets/45de0afb-25bc-4695-a36b-31fc668e559a)

USDC milestone approval:

![localhost_3000_admin (7)](https://github.com/user-attachments/assets/c18b5ae6-eee7-453e-9846-267f84c5783f)

USDC milestone final approval:

![localhost_3000_admin (8)](https://github.com/user-attachments/assets/05ff43a6-46b6-4d9a-a9d5-fbf06e77da5a)

Another option for this one is adding the confirmation text. Please let me know if you think that it's better:

![localhost_3000_admin (9)](https://github.com/user-attachments/assets/03b8afe3-3d8e-4275-9518-ed281e8a3269)

closes #54 