### PR TITLE
Large grant page tweaks

### DIFF
--- a/packages/nextjs/app/large-grants/[grantId]/_components/CurrentStage/MilestoneDetail.tsx
+++ b/packages/nextjs/app/large-grants/[grantId]/_components/CurrentStage/MilestoneDetail.tsx
@@ -26,6 +26,7 @@ export const MilestoneDetail = ({ milestone }: { milestone: LargeMilestone }) =>
           {milestone.status === "approved" ? (
             <Button
               className="w-auto self-start"
+              size="sm"
               onClick={() => {
                 completeMilestoneModalRef.current?.showModal();
               }}

--- a/packages/nextjs/app/large-grants/[grantId]/_components/CurrentStage/MilestoneDetail.tsx
+++ b/packages/nextjs/app/large-grants/[grantId]/_components/CurrentStage/MilestoneDetail.tsx
@@ -56,6 +56,17 @@ export const MilestoneDetail = ({ milestone }: { milestone: LargeMilestone }) =>
               </div>
             )
           )}
+          {milestone.status === "rejected" && (
+            <Button
+              className="w-auto self-start"
+              size="sm"
+              onClick={() => {
+                completeMilestoneModalRef.current?.showModal();
+              }}
+            >
+              Submit again
+            </Button>
+          )}
         </div>
       </div>
 

--- a/packages/nextjs/app/large-grants/[grantId]/_components/ProjectTimeline/TimelineStage.tsx
+++ b/packages/nextjs/app/large-grants/[grantId]/_components/ProjectTimeline/TimelineStage.tsx
@@ -65,7 +65,7 @@ export const TimelineStage = ({ stage }: { stage: LargeStageWithMilestones }) =>
                         />
                       )}
                     </div>
-                    <div className="text-sm font-bold">{milestone.description}</div>
+                    <div className="text-sm">{milestone.description}</div>
                   </div>
                 </div>
               ))}

--- a/packages/nextjs/app/large-grants/[grantId]/_components/ProjectTimeline/TimelineStage.tsx
+++ b/packages/nextjs/app/large-grants/[grantId]/_components/ProjectTimeline/TimelineStage.tsx
@@ -1,5 +1,7 @@
+import { ExclamationCircleIcon } from "@heroicons/react/20/solid";
 import { ChatBubbleOvalLeftEllipsisIcon } from "@heroicons/react/24/outline";
 import { CheckCircleIcon as CheckCircleSolidIcon } from "@heroicons/react/24/solid";
+import { statusText } from "~~/components/pg-ens/BadgeMilestone";
 import { StyledTooltip } from "~~/components/pg-ens/StyledTooltip";
 import { LargeStageWithMilestones } from "~~/services/database/repositories/large-stages";
 import { getFormattedDate } from "~~/utils/getFormattedDate";
@@ -48,11 +50,18 @@ export const TimelineStage = ({ stage }: { stage: LargeStageWithMilestones }) =>
                   <div>
                     <div className={`text-lg font-bold flex ${isOdd ? "" : "sm:place-content-end"}`}>
                       Milestone {idx + 1} ({milestone.amount.toLocaleString()} USDC)
-                      {(milestone.status === "completed" || milestone.status === "paid") && (
+                      {["completed", "verified", "paid"].includes(milestone.status) && (
                         <CheckCircleSolidIcon
                           className={`ml-1 mt-1 h-6 w-6 ${
-                            milestone.status === "paid" ? "text-green-500" : "text-orange-500"
+                            milestone.status === "paid" ? "text-primary-green" : "text-primary-orange"
                           }`}
+                          title={statusText[milestone.status]}
+                        />
+                      )}
+                      {milestone.status === "rejected" && (
+                        <ExclamationCircleIcon
+                          className="ml-1 mt-1 h-6 w-6 text-primary-red"
+                          title={statusText[milestone.status]}
                         />
                       )}
                     </div>

--- a/packages/nextjs/components/pg-ens/BadgeMilestone.tsx
+++ b/packages/nextjs/components/pg-ens/BadgeMilestone.tsx
@@ -26,7 +26,7 @@ type BadgeProps = {
   className?: string;
 };
 
-const statusText: Record<LargeMilestoneStatus, string> = {
+export const statusText: Record<LargeMilestoneStatus, string> = {
   proposed: "Proposed",
   rejected: "Rejected",
   completed: "Completed (Pending Review)",


### PR DESCRIPTION
Items from the related issue #49: 

- Delete the hour from the paid date "Paid on 26/2/2025, 1:00:00". We could set it as 26 Feb 2025 based on https://github.com/BuidlGuidl/ens-pg/issues/40 

Done at https://github.com/BuidlGuidl/ens-pg/pull/74

- Change milestone color in the timeline to yellow (same yellow as "Completed (Pending Review)" for the ones that have Completed status in db

![localhost_3000_large-grants_227 (3)](https://github.com/user-attachments/assets/f2b3b406-46c8-4a26-83d0-7c56315b900e)

- Rejected milestones need to have "Submit again" button and have an icon in the timeline (we can tackle this one when we tackle https://github.com/BuidlGuidl/ens-pg/issues/35)

Added "Submit again" button and rejected icon. Screenshot with rejected icon in the previous item.

- Reduce "Complete" button size in grant detail page.

- The style of milestone description in timeline should be a bit thiner?

Removed bold from milestone descriptions.

closes #49 