### PR TITLE
Milestone approval issues

### DIFF
--- a/packages/nextjs/app/admin/_components/LargeMilestoneApprovalModal/index.tsx
+++ b/packages/nextjs/app/admin/_components/LargeMilestoneApprovalModal/index.tsx
@@ -161,6 +161,7 @@ export const LargeMilestoneApprovalModal = forwardRef<
               <Button
                 variant="secondary"
                 size="sm"
+                type="button"
                 disabled={Boolean(loadingStatus)}
                 className="self-center"
                 onClick={closeModal}

--- a/packages/nextjs/app/admin/_components/LargeMilestoneCompleted.tsx
+++ b/packages/nextjs/app/admin/_components/LargeMilestoneCompleted.tsx
@@ -54,7 +54,7 @@ export const LargeMilestoneCompleted = ({ milestone }: { milestone: LargeMilesto
         </div>
         <div>{milestone.completedAt?.toLocaleDateString()}</div>
       </div>
-      <div className="px-5 py-8 bg-gray-100">
+      <div className={`px-5 pt-8 bg-gray-100 ${isFinalApproveAvailable ? "pb-5" : "pb-8"}`}>
         <div className="flex justify-between">
           <h2 className="text-2xl font-bold mb-0">Milestone {milestone.milestoneNumber}</h2>
           <div className="bg-white rounded-lg p-1">{milestone.amount.toLocaleString()} USDC</div>
@@ -69,6 +69,13 @@ export const LargeMilestoneCompleted = ({ milestone }: { milestone: LargeMilesto
         <div className="mt-6 flex flex-col lg:flex-row gap-1">
           <span className="font-bold">Deadline:</span> {milestone.proposedCompletionDate.toLocaleDateString()}
         </div>
+        {isFinalApproveAvailable && (
+          <div className="flex gap-1 justify-end">
+            <div className="tooltip" data-tip={`Pre-approved by ${milestone.verifiedBy}`}>
+              <div>👍</div>
+            </div>
+          </div>
+        )}
       </div>
 
       <div className="p-5">

--- a/packages/nextjs/app/admin/_components/LargeMilestoneCompleted.tsx
+++ b/packages/nextjs/app/admin/_components/LargeMilestoneCompleted.tsx
@@ -54,20 +54,22 @@ export const LargeMilestoneCompleted = ({ milestone }: { milestone: LargeMilesto
         </div>
         <div>{milestone.completedAt?.toLocaleDateString()}</div>
       </div>
-      <div className={`px-5 pt-8 bg-gray-100 ${isFinalApproveAvailable ? "pb-5" : "pb-8"}`}>
+      <div className={`px-5 pt-5 bg-gray-100 ${isFinalApproveAvailable ? "pb-2" : "pb-5"}`}>
         <div className="flex justify-between">
           <h2 className="text-2xl font-bold mb-0">Milestone {milestone.milestoneNumber}</h2>
           <div className="bg-white rounded-lg p-1">{milestone.amount.toLocaleString()} USDC</div>
         </div>
-        <Link
-          href={`/large-grants/${milestone.stage.grant.id}`}
-          className="text-gray-500 underline flex items-center gap-1 mr-2"
-          target="_blank"
-        >
-          View grant page <ArrowTopRightOnSquareIcon className="w-5 h-5" />
-        </Link>
-        <div className="mt-6 flex flex-col lg:flex-row gap-1">
-          <span className="font-bold">Deadline:</span> {milestone.proposedCompletionDate.toLocaleDateString()}
+        <div className="flex justify-between">
+          <Link
+            href={`/large-grants/${milestone.stage.grant.id}`}
+            className="text-gray-500 underline flex items-center gap-1 mr-2"
+            target="_blank"
+          >
+            View grant page <ArrowTopRightOnSquareIcon className="w-5 h-5" />
+          </Link>
+          <div className="font-semibold">
+            <span>Deadline:</span> {milestone.proposedCompletionDate.toLocaleDateString()}
+          </div>
         </div>
         {isFinalApproveAvailable && (
           <div className="flex gap-1 justify-end">


### PR DESCRIPTION
- Fix trying to approve when cancelling.
- Added pre-approved thumb

Added here a compacted view for milestones from issue #52 too.

![localhost_3000_admin (18)](https://github.com/user-attachments/assets/dfd9fd08-0222-4657-baac-7409e05a65c8)

And with thumb up:

![localhost_3000_admin (17)](https://github.com/user-attachments/assets/6bc851cf-9f96-48e0-a9ba-2a1a3633764c)

The description and the other fields have a line break after the label because these are multiline fields.

closes #82 and #52