### PR TITLE
Milestones small visual changes

### DIFF
--- a/packages/nextjs/app/_components/Grants/GrantMilestonesModal.tsx
+++ b/packages/nextjs/app/_components/Grants/GrantMilestonesModal.tsx
@@ -1,7 +1,7 @@
 import { forwardRef } from "react";
 import { formatEther } from "viem";
 import { WithdrawalItems } from "~~/hooks/pg-ens/useWithdrawals";
-import { getFormattedDate } from "~~/utils/getFormattedDate";
+import { getFormattedDateWithDay } from "~~/utils/getFormattedDate";
 import { multilineStringToTsx } from "~~/utils/multiline-string-to-tsx";
 
 type GrantMilestonesModalProps = {
@@ -33,7 +33,7 @@ export const GrantMilestonesModal = forwardRef<HTMLDialogElement, GrantMilestone
                     {formatEther(BigInt(withdrawal.amount))} ETH
                   </div>
                 </div>
-                <div>{getFormattedDate(new Date(+withdrawal.timestamp * 1000)) || "-"}</div>
+                <div>{getFormattedDateWithDay(new Date(+withdrawal.timestamp * 1000)) || "-"}</div>
               </div>
               <div className="mt-2">{multilineStringToTsx(withdrawal.reason || "-")}</div>
             </div>

--- a/packages/nextjs/app/_components/Grants/LargeGrantMilestonesModal.tsx
+++ b/packages/nextjs/app/_components/Grants/LargeGrantMilestonesModal.tsx
@@ -1,6 +1,6 @@
 import { forwardRef } from "react";
 import { LargeMilestone } from "~~/services/database/repositories/large-milestones";
-import { getFormattedDate } from "~~/utils/getFormattedDate";
+import { getFormattedDateWithDay } from "~~/utils/getFormattedDate";
 import { multilineStringToTsx } from "~~/utils/multiline-string-to-tsx";
 
 type GrantMilestonesModalProps = {
@@ -27,7 +27,7 @@ export const LargeGrantMilestonesModal = forwardRef<HTMLDialogElement, GrantMile
                   <div className="text-lg font-bold">Milestone {index + 1}</div>
                   <div className="bg-secondary px-2 py-1 rounded font-semibold">{milestone.amount} USDC</div>
                 </div>
-                {milestone.completedAt && <div>{getFormattedDate(milestone.completedAt)}</div>}
+                {milestone.completedAt && <div>{getFormattedDateWithDay(milestone.completedAt)}</div>}
               </div>
               <div className="mt-2">{multilineStringToTsx(milestone.completionProof || "-")}</div>
             </div>

--- a/packages/nextjs/app/admin/_components/LargeMilestoneCompleted.tsx
+++ b/packages/nextjs/app/admin/_components/LargeMilestoneCompleted.tsx
@@ -51,14 +51,14 @@ export const LargeMilestoneCompleted = ({ milestone }: { milestone: LargeMilesto
       <div className="px-5 py-3 flex justify-between items-center w-full">
         <div className="font-bold text-xl flex items-center">
           <div className="rounded-full bg-primary h-3.5 w-3.5 min-w-3.5 mr-2" />
-          {milestone.stage.grant.title} - Stage {latestStage.stageNumber}
+          Milestone {milestone.milestoneNumber} - Stage {latestStage.stageNumber}
         </div>
         <div>{milestone.completedAt && getFormattedDateWithDay(milestone.completedAt)}</div>
       </div>
       <div className={`px-5 pt-5 bg-gray-100 ${isFinalApproveAvailable ? "pb-2" : "pb-5"}`}>
         <div className="flex justify-between">
-          <h2 className="text-2xl font-bold mb-0">Milestone {milestone.milestoneNumber}</h2>
-          <div className="bg-white rounded-lg p-1">{milestone.amount.toLocaleString()} USDC</div>
+          <h2 className="text-2xl font-bold mb-0">{milestone.stage.grant.title}</h2>
+          <div className="bg-white rounded-lg p-1 h-8">{milestone.amount.toLocaleString()}&nbsp;USDC</div>
         </div>
         <div className="flex justify-between">
           <Link

--- a/packages/nextjs/app/large-grants/[grantId]/_components/CurrentStage/MilestoneDetail.tsx
+++ b/packages/nextjs/app/large-grants/[grantId]/_components/CurrentStage/MilestoneDetail.tsx
@@ -47,7 +47,9 @@ export const MilestoneDetail = ({ milestone }: { milestone: LargeMilestone }) =>
               <div className="flex flex-row">
                 <BadgeMilestone status={milestone.status} />
                 {["rejected", "paid"].includes(milestone.status) && milestone.statusNote && (
-                  <div className="mt-2 ml-4 text-sm font-bold text-gray-400">Note: {milestone.statusNote}</div>
+                  <div className="mt-2 ml-4 text-sm font-bold text-gray-400">
+                    {milestone.status == "rejected" ? "Rejection notes" : "Note"}: {milestone.statusNote}
+                  </div>
                 )}
                 {milestone.status === "paid" && milestone.paidAt && (
                   <div className="mt-2 ml-4 text-sm font-bold text-gray-400">


### PR DESCRIPTION
1. [Change rejection note label](https://github.com/BuidlGuidl/ens-pg/commit/c5fe826981cbc7d640ee04ad3c9557218eeb4288)
2. [Show full completed at date on USDC milestone modal](https://github.com/BuidlGuidl/ens-pg/commit/df43d35b5c6584951a61939fb2e08231e97577a7)
3. [Show full withdrawal date on ETH milestone modal](https://github.com/BuidlGuidl/ens-pg/commit/c87002cc6703f8f0aa977b3b8c6d66d5f366f1c9)
4. [Move grant title to middle layer of admin milestone card](https://github.com/BuidlGuidl/ens-pg/commit/cb028a8bfe78acb772522e5950a51bee82e1c6b3)

Before:

![localhost_3000_admin (20)](https://github.com/user-attachments/assets/8c78a202-4e5a-47d2-abed-80726d9a4cc0)

Now:

![localhost_3000_admin (21)](https://github.com/user-attachments/assets/8e186fcc-c1a5-423c-9865-f3c970e0b52c)

I think it's much better now.

closes #92 