### PR TITLE
New approval flow

### DIFF
--- a/packages/nextjs/app/admin/_components/LargeGrantProposal.tsx
+++ b/packages/nextjs/app/admin/_components/LargeGrantProposal.tsx
@@ -47,7 +47,7 @@ export const LargeGrantProposal = ({ proposal, userSubmissionsAmount, isGrant }:
   const latestStage = proposal.stages[0];
   const { privateNotes, approvalVotes, rejectVotes } = latestStage;
 
-  const isFinalApproveAvailable = approvalVotes && approvalVotes.length >= MINIMAL_VOTES_FOR_FINAL_APPROVAL;
+  const isFinalApproveAvailable = approvalVotes && approvalVotes.length + 1 >= MINIMAL_VOTES_FOR_FINAL_APPROVAL;
   const isFinalRejectAvailable = rejectVotes && rejectVotes.length + 1 >= MINIMAL_VOTES_FOR_FINAL_APPROVAL;
 
   const milestonesToShow = latestStage.milestones;
@@ -160,13 +160,17 @@ export const LargeGrantProposal = ({ proposal, userSubmissionsAmount, isGrant }:
             </Button>
 
             {isFinalApproveAvailable ? (
-              <Button
-                variant="green"
-                size="sm"
-                onClick={() => finalApproveModalRef && finalApproveModalRef.current?.showModal()}
-              >
-                Final Approve
-              </Button>
+              <div className="flex flex-col gap-1">
+                <Button
+                  variant="green"
+                  size="sm"
+                  onClick={() => finalApproveModalRef && finalApproveModalRef.current?.showModal()}
+                  disabled={!canVote}
+                >
+                  Final Approve
+                </Button>
+                {!canVote && <FormErrorMessage error="Voted" className="text-center" />}
+              </div>
             ) : (
               <div className="flex flex-col gap-1">
                 <Button

--- a/packages/nextjs/app/admin/_components/Proposal.tsx
+++ b/packages/nextjs/app/admin/_components/Proposal.tsx
@@ -45,7 +45,7 @@ export const Proposal = ({ proposal, userSubmissionsAmount, isGrant }: ProposalP
   const { privateNotes, approvalVotes } = latestStage;
   const canVote = !approvalVotes || approvalVotes.every(vote => vote.authorAddress !== address);
 
-  const isFinalApproveAvailable = approvalVotes && approvalVotes.length >= MINIMAL_VOTES_FOR_FINAL_APPROVAL;
+  const isFinalApproveAvailable = approvalVotes && approvalVotes.length + 1 >= MINIMAL_VOTES_FOR_FINAL_APPROVAL;
 
   const milestonesToShow = latestStage.stageNumber > 1 ? latestStage.milestone : proposal.milestones;
 
@@ -122,13 +122,17 @@ export const Proposal = ({ proposal, userSubmissionsAmount, isGrant }: ProposalP
             </Button>
 
             {isFinalApproveAvailable ? (
-              <Button
-                variant="green"
-                size="sm"
-                onClick={() => finalApproveModalRef && finalApproveModalRef.current?.showModal()}
-              >
-                Final Approve
-              </Button>
+              <div className="flex flex-col gap-1">
+                <Button
+                  variant="green"
+                  size="sm"
+                  onClick={() => finalApproveModalRef && finalApproveModalRef.current?.showModal()}
+                  disabled={!canVote}
+                >
+                  Final Approve
+                </Button>
+                {!canVote && <FormErrorMessage error="Voted" className="text-center" />}
+              </div>
             ) : (
               <div className="flex flex-col gap-1">
                 <Button


### PR DESCRIPTION
Implemented on USDC grants and ETH grants.

To approve a new grant or a new stage, one admin makes a first approval, and the second admin can do the final approval (there is no need to do a second approval before the final approval).

closes #95 #96