### PR TITLE
Fix milestone flow when an admin rejects after one approval

### DIFF
--- a/packages/nextjs/app/api/large-milestones/[milestoneId]/review/route.ts
+++ b/packages/nextjs/app/api/large-milestones/[milestoneId]/review/route.ts
@@ -89,8 +89,15 @@ export async function POST(req: NextRequest, { params }: { params: { milestoneId
           }
         : {};
 
+    let status = body.status;
+
+    if (status === "completed" && milestone.verifiedAt) {
+      // if the milestone is completed, set the status to "verified" if it was verified before
+      status = "verified";
+    }
+
     await updateMilestone(Number(milestoneId), {
-      status: body.status,
+      status,
       statusNote: session?.user.role === "admin" ? body.statusNote : undefined,
       completionProof: body.completionProof,
       ...verifiedObj,


### PR DESCRIPTION
When the milestone was resent, the status was set to completed, but one approval was already done.

Now the milestone is set to **verified** if the milestone is completed, but a verification was previously done.

fixes #89 