### PR TITLE
Fix TG bot notifications and add notifications to milestone completion

### DIFF
--- a/packages/nextjs/app/api/large-grants/new/route.ts
+++ b/packages/nextjs/app/api/large-grants/new/route.ts
@@ -42,7 +42,7 @@ export async function POST(req: Request) {
 
     await notifyTelegramBot("largeGrant", {
       id: result.grantId,
-      ...formattedBody,
+      ...body,
       builderAddress,
     });
 

--- a/packages/nextjs/app/api/large-milestones/[milestoneId]/review/route.ts
+++ b/packages/nextjs/app/api/large-milestones/[milestoneId]/review/route.ts
@@ -7,6 +7,7 @@ import {
   updateMilestone,
 } from "~~/services/database/repositories/large-milestones";
 import { getStageWithMilestones, updateStageStatusToCompleted } from "~~/services/database/repositories/large-stages";
+import { notifyTelegramBot } from "~~/services/notifications/telegram";
 import { authOptions } from "~~/utils/auth";
 import { EIP_712_DOMAIN, EIP_712_TYPES__REVIEW_LARGE_MILESTONE } from "~~/utils/eip712";
 
@@ -116,6 +117,10 @@ export async function POST(req: NextRequest, { params }: { params: { milestoneId
       if (allMilestonesPaid) {
         await updateStageStatusToCompleted(stage.id);
       }
+    }
+
+    if (status === "completed") {
+      await notifyTelegramBot("largeMilestone", { largeMilestone: milestone });
     }
 
     return NextResponse.json({ milestoneId, status }, { status: 200 });

--- a/packages/nextjs/app/api/large-milestones/[milestoneId]/review/route.ts
+++ b/packages/nextjs/app/api/large-milestones/[milestoneId]/review/route.ts
@@ -120,7 +120,9 @@ export async function POST(req: NextRequest, { params }: { params: { milestoneId
     }
 
     if (status === "completed") {
-      await notifyTelegramBot("largeMilestone", { largeMilestone: milestone });
+      // Fetch the updated milestone
+      const updatedMilestone = await getMilestoneByIdWithRelatedData(Number(milestoneId));
+      await notifyTelegramBot("largeMilestone", { largeMilestone: updatedMilestone });
     }
 
     return NextResponse.json({ milestoneId, status }, { status: 200 });

--- a/packages/nextjs/app/api/large-stages/new/route.ts
+++ b/packages/nextjs/app/api/large-stages/new/route.ts
@@ -71,6 +71,7 @@ export async function POST(req: Request) {
 
     await notifyTelegramBot("largeStage", {
       newLargeStage: body,
+      largeGrant: grant,
     });
 
     return NextResponse.json({ stageId: createdStage.stageId }, { status: 201 });

--- a/packages/nextjs/services/notifications/telegram.ts
+++ b/packages/nextjs/services/notifications/telegram.ts
@@ -1,3 +1,5 @@
+import { getLargeGrantById } from "../database/repositories/large-grants";
+import { getMilestoneByIdWithRelatedData } from "../database/repositories/large-milestones";
 import { CreateNewGrantReqBody } from "~~/app/api/grants/new/route";
 import { CreateNewLargeGrantReqBody } from "~~/app/api/large-grants/new/route";
 import { CreateNewLargeStageReqBody } from "~~/app/api/large-stages/new/route";
@@ -7,17 +9,21 @@ import { GrantWithStages } from "~~/app/grants/[grantId]/page";
 const TELEGRAM_BOT_URL = process.env.TELEGRAM_BOT_URL;
 const TELEGRAM_WEBHOOK_SECRET = process.env.TELEGRAM_WEBHOOK_SECRET;
 
+export type LargeGrantDataFromDB = Awaited<ReturnType<typeof getLargeGrantById>>;
+export type MilestoneDataFromDB = Awaited<ReturnType<typeof getMilestoneByIdWithRelatedData>>;
+
 type StageData = {
   newStage?: CreateNewStageReqBody;
   newLargeStage?: CreateNewLargeStageReqBody;
   grant?: GrantWithStages;
-  largeGrant?: CreateNewLargeGrantReqBody;
+  largeGrant?: CreateNewLargeGrantReqBody | LargeGrantDataFromDB;
+  largeMilestone?: MilestoneDataFromDB;
 };
 
 type GrantData = CreateNewGrantReqBody & { builderAddress: string };
 type LargeGrantData = CreateNewLargeGrantReqBody & { builderAddress: string };
 
-export async function notifyTelegramBot<T extends "grant" | "stage" | "largeGrant" | "largeStage">(
+export async function notifyTelegramBot<T extends "grant" | "stage" | "largeGrant" | "largeStage" | "largeMilestone">(
   endpoint: T,
   data: T extends "grant" ? GrantData : T extends "largeGrant" ? LargeGrantData : StageData,
 ) {


### PR DESCRIPTION
This PR fixes the notifications for large grants and new large grant stages. And add notifications when a milestone from a USDC grant is completed.

This needs to be tested after https://github.com/BuidlGuidl/ens-pg-admin-bot/pull/2 is merged.

This needs to run the telegram bot locally.

fixes #64 