### PR TITLE
Export grants and large grants to markdown

### DIFF
--- a/packages/nextjs/app/_components/Grants/GrantItem.tsx
+++ b/packages/nextjs/app/_components/Grants/GrantItem.tsx
@@ -1,8 +1,9 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import Link from "next/link";
+import { ExportGrantMarkdown } from "../../admin/_components/ExportGrantMarkdown";
 import { GrantMilestonesModal } from "./GrantMilestonesModal";
 import { formatEther } from "viem";
-import { MagnifyingGlassIcon } from "@heroicons/react/24/outline";
+import { ClipboardIcon } from "@heroicons/react/24/outline";
 import { Badge } from "~~/components/pg-ens/Badge";
 import { Button } from "~~/components/pg-ens/Button";
 import { GrantProgressBar } from "~~/components/pg-ens/GrantProgressBar";
@@ -11,17 +12,21 @@ import { useAuthSession } from "~~/hooks/pg-ens/useAuthSession";
 import { useWithdrawals } from "~~/hooks/pg-ens/useWithdrawals";
 import { PublicGrant } from "~~/services/database/repositories/grants";
 import { Stage } from "~~/services/database/repositories/stages";
+import { AdminGrant } from "~~/types/utils";
 import { getFormattedDate } from "~~/utils/getFormattedDate";
 import { multilineStringToTsx } from "~~/utils/multiline-string-to-tsx";
 
 type GrantItemProps = {
-  grant: PublicGrant;
+  grant: PublicGrant | AdminGrant;
   latestsShownStatus: "all" | "approved";
 };
 
 export const GrantItem = ({ grant, latestsShownStatus }: GrantItemProps) => {
   const milestonesRef = useRef<HTMLDialogElement>(null);
   const { isAdmin } = useAuthSession();
+
+  const [showMarkdown, setShowMarkdown] = useState(false);
+  const [copied, setCopied] = useState(false);
 
   const latestStage =
     latestsShownStatus === "approved"
@@ -49,6 +54,20 @@ export const GrantItem = ({ grant, latestsShownStatus }: GrantItemProps) => {
     .filter(withdrawAmount => withdrawAmount)
     .reduce((acc, current) => BigInt(acc || 0n) + BigInt(current || 0n), 0n);
 
+  // Only generate markdown if grant is an AdminGrant
+  const markdown = "email" in grant ? ExportGrantMarkdown({ grant }) : "";
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(markdown);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setCopied(false);
+      alert("Failed to copy!");
+    }
+  };
+
   return (
     <div className="card flex flex-col bg-white text-primary-content w-full max-w-96 shadow-lg rounded-lg overflow-hidden">
       <div className="px-3 py-3 flex justify-between items-center w-full">
@@ -63,8 +82,20 @@ export const GrantItem = ({ grant, latestsShownStatus }: GrantItemProps) => {
         <div className="flex items-start mb-6">
           {isAdmin ? (
             <Link href={`/grants/${grant.id}`} className="hover:underline flex items-start">
-              <h2 className="text-2xl font-bold pr-2 flex-grow">{grant.title}</h2>
-              <MagnifyingGlassIcon className="flex-shrink-0 w-6 h-6 text-gray-500 mt-1" />
+              <h2 className="text-2xl font-bold pr-2 flex-grow flex items-center">
+                {grant.title}
+                <button
+                  type="button"
+                  className="ml-2 p-1 rounded hover:bg-gray-200"
+                  onClick={e => {
+                    e.preventDefault();
+                    setShowMarkdown(true);
+                  }}
+                  title="Export to Markdown"
+                >
+                  <ClipboardIcon className="w-5 h-5 text-gray-500" />
+                </button>
+              </h2>
             </Link>
           ) : (
             <h2 className="text-2xl font-bold">{grant.title}</h2>
@@ -92,6 +123,25 @@ export const GrantItem = ({ grant, latestsShownStatus }: GrantItemProps) => {
         )}
         <GrantMilestonesModal ref={milestonesRef} withdrawals={allWithdrawals} id={grant.id} />
       </div>
+      {showMarkdown && (
+        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+          <div className="bg-white p-6 rounded shadow-lg max-w-2xl w-full">
+            <h2 className="text-xl font-bold mb-4">Exported Markdown</h2>
+            <textarea className="w-full h-64 p-2 border rounded mb-4" value={markdown} readOnly />
+            <div className="flex justify-end gap-2">
+              <button className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700" onClick={handleCopy}>
+                {copied ? "Copied!" : "Copy to Clipboard"}
+              </button>
+              <button
+                className="px-4 py-2 bg-gray-300 rounded hover:bg-gray-400"
+                onClick={() => setShowMarkdown(false)}
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/nextjs/app/_components/Grants/LargeGrantItem.tsx
+++ b/packages/nextjs/app/_components/Grants/LargeGrantItem.tsx
@@ -1,7 +1,8 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import Link from "next/link";
+import { ExportLargeGrantMarkdown } from "../../admin/_components/ExportLargeGrantMarkdown";
 import { LargeGrantMilestonesModal } from "./LargeGrantMilestonesModal";
-import { MagnifyingGlassIcon } from "@heroicons/react/24/outline";
+import { ClipboardIcon } from "@heroicons/react/24/outline";
 import { Badge } from "~~/components/pg-ens/Badge";
 import { Button } from "~~/components/pg-ens/Button";
 import { GrantProgressBar } from "~~/components/pg-ens/GrantProgressBar";
@@ -10,17 +11,20 @@ import { useAuthSession } from "~~/hooks/pg-ens/useAuthSession";
 import { PublicLargeGrant } from "~~/services/database/repositories/large-grants";
 import { LargeMilestone } from "~~/services/database/repositories/large-milestones";
 import { LargeStage } from "~~/services/database/repositories/large-stages";
+import { AdminLargeGrant } from "~~/types/utils";
 import { getFormattedDate } from "~~/utils/getFormattedDate";
 import { multilineStringToTsx } from "~~/utils/multiline-string-to-tsx";
 
 type GrantItemProps = {
-  grant: PublicLargeGrant;
+  grant: PublicLargeGrant | AdminLargeGrant;
   latestsShownStatus: "all" | "approved";
 };
 
 export const LargeGrantItem = ({ grant, latestsShownStatus }: GrantItemProps) => {
   const milestonesRef = useRef<HTMLDialogElement>(null);
   const { isAdmin } = useAuthSession();
+  const [showMarkdown, setShowMarkdown] = useState(false);
+  const [copied, setCopied] = useState(false);
 
   const latestStage =
     latestsShownStatus === "approved"
@@ -45,6 +49,20 @@ export const LargeGrantItem = ({ grant, latestsShownStatus }: GrantItemProps) =>
 
   const completedMilestonesAmount = completedMilestones.reduce((acc, current) => acc + current.amount, 0);
 
+  // Only generate markdown if grant is an AdminLargeGrant
+  const markdown = "email" in grant ? ExportLargeGrantMarkdown({ grant }) : "";
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(markdown);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setCopied(false);
+      alert("Failed to copy!");
+    }
+  };
+
   return (
     <div className="card flex flex-col bg-white text-primary-content w-full max-w-96 shadow-lg rounded-lg overflow-hidden">
       <div className="px-3 py-3 flex justify-between items-center w-full">
@@ -59,8 +77,20 @@ export const LargeGrantItem = ({ grant, latestsShownStatus }: GrantItemProps) =>
         <div className="flex items-start mb-6">
           {isAdmin ? (
             <Link href={`/large-grants/${grant.id}`} className="hover:underline flex items-start">
-              <h2 className="text-2xl font-bold pr-2 flex-grow">{grant.title}</h2>
-              <MagnifyingGlassIcon className="flex-shrink-0 w-6 h-6 text-gray-500 mt-1" />
+              <h2 className="text-2xl font-bold pr-2 flex-grow flex items-center">
+                {grant.title}
+                <button
+                  type="button"
+                  className="ml-2 p-1 rounded hover:bg-gray-200"
+                  onClick={e => {
+                    e.preventDefault();
+                    setShowMarkdown(true);
+                  }}
+                  title="Export to Markdown"
+                >
+                  <ClipboardIcon className="w-5 h-5 text-gray-500" />
+                </button>
+              </h2>
             </Link>
           ) : (
             <h2 className="text-2xl font-bold">{grant.title}</h2>
@@ -93,6 +123,25 @@ export const LargeGrantItem = ({ grant, latestsShownStatus }: GrantItemProps) =>
           id={grant.id}
         />
       </div>
+      {showMarkdown && (
+        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+          <div className="bg-white p-6 rounded shadow-lg max-w-2xl w-full">
+            <h2 className="text-xl font-bold mb-4">Exported Markdown</h2>
+            <textarea className="w-full h-64 p-2 border rounded mb-4" value={markdown} readOnly />
+            <div className="flex justify-end gap-2">
+              <button className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700" onClick={handleCopy}>
+                {copied ? "Copied!" : "Copy to Clipboard"}
+              </button>
+              <button
+                className="px-4 py-2 bg-gray-300 rounded hover:bg-gray-400"
+                onClick={() => setShowMarkdown(false)}
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/nextjs/app/admin/_components/ExportGrantMarkdown.tsx
+++ b/packages/nextjs/app/admin/_components/ExportGrantMarkdown.tsx
@@ -1,0 +1,48 @@
+import { formatEther } from "viem";
+import { AdminGrant } from "~~/types/utils";
+import { getFormattedDateWithDay } from "~~/utils/getFormattedDate";
+
+export function ExportGrantMarkdown({ grant }: { grant: AdminGrant }) {
+  let md = `## ETH Grant: ${grant.title}\n`;
+  md += `- **ID:** ${grant.id}\n`;
+  md += `- **Builder:** ${grant.builderAddress}\n`;
+  if (grant.submitedAt) {
+    md += `- **Submitted At:** ${getFormattedDateWithDay(grant.submitedAt)}\n`;
+  }
+  if (grant.showcaseVideoUrl) {
+    md += `- **Showcase Video URL:** ${grant.showcaseVideoUrl}\n`;
+  }
+  md += `- **GitHub:** ${grant.github}\n`;
+  md += `- **Email:** ${grant.email}\n`;
+  md += `- **Twitter:** ${grant.twitter}\n`;
+  md += `- **Telegram:** ${grant.telegram}\n`;
+  md += `### Description\n${grant.description}\n\n`;
+
+  md += `### Stages\n`;
+  grant.stages.forEach(stage => {
+    md += `#### Stage ${stage.stageNumber} (${stage.status})\n`;
+
+    if (stage.stageNumber > 1 && "grantAmount" in stage && stage.grantAmount) {
+      md += `- **Grant Amount:** ${formatEther(stage.grantAmount)} ETH\n`;
+    }
+
+    if (stage.stageNumber === 1 && grant.requestedFunds) {
+      md += `- **Grant Amount:** ${formatEther(grant.requestedFunds)} ETH\n`;
+    }
+
+    if (stage.stageNumber > 1) {
+      md += `##### Milestones\n\n ${"milestone" in stage ? stage.milestone ?? "" : ""}\n`;
+    } else {
+      md += `##### Milestones\n\n  ${grant.milestones}\n`;
+    }
+
+    if (stage.privateNotes?.length) {
+      md += `##### Private Notes\n`;
+      stage.privateNotes.forEach(note => {
+        md += `- ${note.note} (by ${note.authorAddress})\n`;
+      });
+    }
+  });
+  md += "\n";
+  return md;
+}

--- a/packages/nextjs/app/admin/_components/ExportGrantsToMarkdown.tsx
+++ b/packages/nextjs/app/admin/_components/ExportGrantsToMarkdown.tsx
@@ -1,0 +1,32 @@
+import { ExportGrantMarkdown } from "./ExportGrantMarkdown";
+import { ExportLargeGrantMarkdown } from "./ExportLargeGrantMarkdown";
+import ExportMarkdownButton from "./ExportMarkdownButton";
+import { getAllGrants } from "~~/services/database/repositories/grants";
+import { getAllLargeGrants } from "~~/services/database/repositories/large-grants";
+import type { DiscriminatedAdminGrant } from "~~/types/utils";
+
+export default async function ExportGrantsToMarkdown() {
+  const grants = (await getAllGrants()).map(grant => ({ ...grant, type: "grant" }));
+  const largeGrants = (await getAllLargeGrants()).map(grant => ({
+    ...grant,
+    type: "largeGrant",
+  }));
+  const allGrants = ([...grants, ...largeGrants] as DiscriminatedAdminGrant[]).sort(
+    (a, b) => (b.submitedAt?.getTime() ?? 0) - (a.submitedAt?.getTime() ?? 0),
+  );
+
+  function generateMarkdown() {
+    let md = "# Grants Export\n\n";
+    allGrants.forEach(grant => {
+      if (grant.type === "grant") {
+        md += ExportGrantMarkdown({ grant });
+      } else if (grant.type === "largeGrant") {
+        md += ExportLargeGrantMarkdown({ grant });
+      }
+    });
+
+    return md;
+  }
+
+  return <ExportMarkdownButton markdown={generateMarkdown()} />;
+}

--- a/packages/nextjs/app/admin/_components/ExportLargeGrantMarkdown.tsx
+++ b/packages/nextjs/app/admin/_components/ExportLargeGrantMarkdown.tsx
@@ -1,0 +1,79 @@
+import { statusText } from "~~/components/pg-ens/BadgeMilestone";
+import { AdminLargeGrant } from "~~/types/utils";
+import { getFormattedDateWithDay, getFormattedDeadline } from "~~/utils/getFormattedDate";
+
+export function ExportLargeGrantMarkdown({ grant }: { grant: AdminLargeGrant }) {
+  let md = `## USDC Grant: ${grant.title}\n`;
+  md += `- **ID:** ${grant.id}\n`;
+  md += `- **Builder:** ${grant.builderAddress}\n`;
+  if (grant.submitedAt) {
+    md += `- **Submitted At:** ${getFormattedDateWithDay(grant.submitedAt)}\n`;
+  }
+  if (grant.showcaseVideoUrl) {
+    md += `- **Showcase Video URL:** ${grant.showcaseVideoUrl}\n`;
+  }
+  md += `- **GitHub:** ${grant.github}\n`;
+  md += `- **Email:** ${grant.email}\n`;
+  md += `- **Twitter:** ${grant.twitter}\n`;
+  md += `- **Telegram:** ${grant.telegram}\n`;
+  md += `### Description\n${grant.description}\n\n`;
+
+  md += `### Stages\n`;
+  grant.stages.forEach(stage => {
+    md += `#### Stage ${stage.stageNumber} (${stage.status})\n`;
+
+    if ("milestones" in stage && Array.isArray(stage.milestones) && stage.milestones.length) {
+      md += `##### Milestones\n\n`;
+      stage.milestones.forEach(milestone => {
+        md += `###### Milestone ${milestone.milestoneNumber} (${statusText[milestone.status]})\n`;
+        md += `- **Description:** ${milestone.description}\n`;
+        md += `- **Detail of Deliverables:** ${milestone.proposedDeliverables}\n`;
+        md += `- **Amount:** ${milestone.amount.toLocaleString()} USDC\n`;
+
+        if (milestone.privateNotes?.length) {
+          md += `####### Private Notes\n`;
+          milestone.privateNotes.forEach(note => {
+            md += `- ${note.note} (by ${note.authorAddress})\n`;
+          });
+        }
+
+        if (milestone.proposedCompletionDate) {
+          md += `- **Deadline:** ${getFormattedDeadline(milestone.proposedCompletionDate)}\n`;
+        }
+        if (milestone.completedAt) {
+          md += `- **Completed At:** ${getFormattedDateWithDay(milestone.completedAt)}\n`;
+        }
+        if (milestone.completionProof) {
+          md += `- **Completion Proof:** ${milestone.completionProof}\n`;
+        }
+        if (milestone.statusNote) {
+          md += `- **Status Note:** ${milestone.statusNote}\n`;
+        }
+        if (milestone.verifiedAt) {
+          md += `- **Verified At:** ${getFormattedDateWithDay(milestone.verifiedAt)}\n`;
+        }
+        if (milestone.verifiedBy) {
+          md += `- **Verified By:** ${milestone.verifiedBy}\n`;
+        }
+        if (milestone.paidAt) {
+          md += `- **Paid At:** ${getFormattedDateWithDay(milestone.paidAt)}\n`;
+        }
+        if (milestone.paidBy) {
+          md += `- **Paid By:** ${milestone.paidBy}\n`;
+        }
+        if (milestone.paymentTx) {
+          md += `- **Payment Tx:** https://optimistic.etherscan.io/tx/${milestone.paymentTx}\n`;
+        }
+      });
+    }
+
+    if (stage.privateNotes?.length) {
+      md += `##### Private Notes\n`;
+      stage.privateNotes.forEach(note => {
+        md += `- ${note.note} (by ${note.authorAddress})\n`;
+      });
+    }
+  });
+  md += "\n";
+  return md;
+}

--- a/packages/nextjs/app/admin/_components/ExportMarkdownButton.tsx
+++ b/packages/nextjs/app/admin/_components/ExportMarkdownButton.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useState } from "react";
+
+export default function ExportMarkdownButton({ markdown }: { markdown: string }) {
+  const [show, setShow] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(markdown);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setCopied(false);
+      alert("Failed to copy!");
+    }
+  };
+
+  return (
+    <>
+      <button
+        className="mb-6 self-end px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+        onClick={() => setShow(true)}
+      >
+        Export to Markdown
+      </button>
+      {show && (
+        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+          <div className="bg-white p-6 rounded shadow-lg max-w-2xl w-full">
+            <h2 className="text-xl font-bold mb-4">Exported Markdown</h2>
+            <textarea className="w-full h-64 p-2 border rounded mb-4" value={markdown} readOnly />
+            <div className="flex justify-end gap-2">
+              <button className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700" onClick={handleCopy}>
+                {copied ? "Copied!" : "Copy to Clipboard"}
+              </button>
+              <button className="px-4 py-2 bg-gray-300 rounded hover:bg-gray-400" onClick={() => setShow(false)}>
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/packages/nextjs/app/admin/page.tsx
+++ b/packages/nextjs/app/admin/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from "next/navigation";
+import ExportGrantsToMarkdown from "./_components/ExportGrantsToMarkdown";
 import { LargeGrantProposal } from "./_components/LargeGrantProposal";
 import { LargeMilestoneCompleted } from "./_components/LargeMilestoneCompleted";
 import { Proposal } from "./_components/Proposal";
@@ -65,6 +66,7 @@ const Admin: NextPage = async () => {
 
   return (
     <div className="flex flex-col flex-grow px-4 py-10 sm:py-20">
+      <ExportGrantsToMarkdown />
       <h1 className="text-3xl text-center font-extrabold !mb-0">Pending proposals</h1>
 
       <div className="mt-10 mx-auto grid xl:grid-cols-3 gap-4 sm:gap-8 w-full">

--- a/packages/nextjs/services/database/repositories/grants.ts
+++ b/packages/nextjs/services/database/repositories/grants.ts
@@ -13,6 +13,9 @@ export async function getAllGrants() {
       stages: {
         // this makes sure latest stage is first
         orderBy: [desc(stages.stageNumber)],
+        with: {
+          privateNotes: true,
+        },
       },
     },
   });

--- a/packages/nextjs/services/database/repositories/large-grants.ts
+++ b/packages/nextjs/services/database/repositories/large-grants.ts
@@ -18,8 +18,12 @@ export async function getAllLargeGrants() {
         orderBy: [desc(largeStages.stageNumber)],
         with: {
           milestones: {
-            orderBy: [desc(largeMilestones.milestoneNumber)],
+            orderBy: [asc(largeMilestones.milestoneNumber)],
+            with: {
+              privateNotes: true,
+            },
           },
+          privateNotes: true,
         },
       },
     },


### PR DESCRIPTION
Allow to export grants and large grants to markdown:

- Added a button at the top of the admin page to export all the grants and large grants. The button style can be improved.
- Added a button after each grant or large grant title on admin cards to export this grant to markdown.
- Added a button after each grant or large grant title on All Grants page to export this grant to markdown.

closes #107 