### PR TITLE
Add milestones to ETH grants and change apply page

### DIFF
--- a/packages/nextjs/app/admin/_components/ExportGrantMarkdown.tsx
+++ b/packages/nextjs/app/admin/_components/ExportGrantMarkdown.tsx
@@ -42,7 +42,7 @@ export function ExportGrantMarkdown({ grant }: { grant: AdminGrant }) {
       md += `##### Milestones\n\n ${
         "milestone" in stage && stage.milestone ? multilineStringToMarkdown(stage.milestone) : ""
       }\n`;
-    } else {
+    } else if (grant.milestones) {
       md += `##### Milestones\n\n  ${multilineStringToMarkdown(grant.milestones)}\n`;
     }
   });

--- a/packages/nextjs/app/api/grants/new/route.ts
+++ b/packages/nextjs/app/api/grants/new/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
+import { parseEther } from "viem";
 import { applyFormSchema } from "~~/app/apply/schema";
 import { GrantInsertWithMilestones, createGrant } from "~~/services/database/repositories/grants";
 import { notifyTelegramBot } from "~~/services/notifications/telegram";
@@ -24,6 +25,10 @@ export async function POST(req: Request) {
     }
 
     const totalAmount = body.milestones.reduce((sum, milestone) => sum + BigInt(milestone.requestedAmount), 0n);
+
+    if (totalAmount > parseEther("2")) {
+      return NextResponse.json({ error: "Total requested funds should not exceed 2 ETH" }, { status: 400 });
+    }
 
     const result = await createGrant({
       ...body,

--- a/packages/nextjs/app/api/grants/new/route.ts
+++ b/packages/nextjs/app/api/grants/new/route.ts
@@ -1,15 +1,11 @@
 import { NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
-import { parseEther } from "viem";
 import { applyFormSchema } from "~~/app/apply/schema";
-import { GrantInsert, createGrant } from "~~/services/database/repositories/grants";
-import { createStage } from "~~/services/database/repositories/stages";
+import { GrantInsertWithMilestones, createGrant } from "~~/services/database/repositories/grants";
 import { notifyTelegramBot } from "~~/services/notifications/telegram";
 import { authOptions } from "~~/utils/auth";
 
-export type CreateNewGrantReqBody = Omit<GrantInsert, "requestedFunds" | "builderAddress"> & {
-  requestedFunds: string;
-};
+export type CreateNewGrantReqBody = Omit<GrantInsertWithMilestones, "builderAddress" | "requestedFunds">;
 
 export async function POST(req: Request) {
   try {
@@ -27,23 +23,21 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Invalid form details submitted" }, { status: 400 });
     }
 
-    const [createdGrant] = await createGrant({
+    const totalAmount = body.milestones.reduce((sum, milestone) => sum + BigInt(milestone.requestedAmount), 0n);
+
+    const result = await createGrant({
       ...body,
       builderAddress,
-      requestedFunds: parseEther(body.requestedFunds),
-    });
-
-    const [createdStage] = await createStage({
-      grantId: createdGrant.id,
+      requestedFunds: totalAmount,
     });
 
     await notifyTelegramBot("grant", {
-      id: createdGrant.id,
+      id: result.grantId,
       ...body,
       builderAddress,
     });
 
-    return NextResponse.json({ grantId: createdGrant.id, stageId: createdStage.id }, { status: 201 });
+    return NextResponse.json({ grantId: result.grantId, stageId: result.stageId }, { status: 201 });
   } catch (error) {
     console.error(error);
     return NextResponse.json({ error: "Error creating grant" }, { status: 500 });

--- a/packages/nextjs/app/apply/page.tsx
+++ b/packages/nextjs/app/apply/page.tsx
@@ -8,9 +8,11 @@ import { ApplyFormValues, applyFormSchema } from "./schema";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
 import { useMutation } from "@tanstack/react-query";
 import type { NextPage } from "next";
-import { FormProvider } from "react-hook-form";
+import { FormProvider, useFieldArray } from "react-hook-form";
 import { Toaster } from "react-hot-toast";
+import { parseEther } from "viem";
 import { useAccount } from "wagmi";
+import { TrashIcon } from "@heroicons/react/20/solid";
 import { Button } from "~~/components/pg-ens/Button";
 import { FormInput } from "~~/components/pg-ens/form-fields/FormInput";
 import { FormSelect } from "~~/components/pg-ens/form-fields/FormSelect";
@@ -24,8 +26,15 @@ const Apply: NextPage = () => {
   const { address: connectedAddress } = useAccount();
   const { data: session } = useAuthSession();
   const router = useRouter();
-  const { formMethods, getCommonOptions } = useFormMethods<ApplyFormValues>({ schema: applyFormSchema });
-  const { handleSubmit } = formMethods;
+
+  const { formMethods, getCommonOptions } = useFormMethods<ApplyFormValues>({
+    schema: applyFormSchema,
+    defaultValues: {
+      milestones: [{ description: "", proposedDeliverables: "", amount: 0, proposedCompletionDate: new Date() }],
+    },
+  });
+
+  const { handleSubmit, control, watch } = formMethods;
 
   const { openConnectModal } = useConnectModal();
   const { isAuthenticated } = useAuthSession();
@@ -46,8 +55,16 @@ const Apply: NextPage = () => {
     try {
       if (!connectedAddress) return notification.error("Please connect your wallet");
 
-      await postNewGrant({
+      const formattedBody = {
         ...fieldValues,
+        milestones: fieldValues.milestones.map(milestone => ({
+          ...milestone,
+          requestedAmount: parseEther(milestone.requestedAmount),
+        })),
+      };
+
+      await postNewGrant({
+        ...formattedBody,
       });
       notification.success(`The grant proposal has been created`);
       feedbackModalRef.current?.showModal();
@@ -62,12 +79,23 @@ const Apply: NextPage = () => {
     router.push("/my-grants");
   };
 
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: "milestones",
+  });
+
+  const watchMilestones = watch("milestones");
+  const totalAmount = watchMilestones.reduce((acc, curr) => acc + Number(curr.requestedAmount), 0);
+
   return (
     <div className="flex flex-col w-full items-center justify-center p-6 sm:p-10">
       <h2 className="text-2xl sm:text-3xl font-extrabold !mb-0">Apply for a grant</h2>
       <p className="text-center text-lg text-base-content/80 mt-4 max-w-2xl">
         Open to all public goods projects. ENS-specific projects should apply through the ENS Ecosystem Grants program
         instead.
+      </p>
+      <p className="text-center text-lg text-base-content/80 mt-4 max-w-2xl">
+        Define your milestones and the budget for each one.
       </p>
 
       <dialog ref={feedbackModalRef} className="modal">
@@ -96,13 +124,69 @@ const Apply: NextPage = () => {
           <form onSubmit={handleSubmit(onSubmit)} className="card-body gap-3 sm:gap-1">
             <FormInput label="Title" {...getCommonOptions("title")} />
             <FormTextarea label="Description" showMessageLength {...getCommonOptions("description")} />
-            <FormTextarea label="Planned Milestones" showMessageLength {...getCommonOptions("milestones")} />
+
+            <div className="mt-4">
+              <h3 className="text-2xl font-bold">Planned Milestones</h3>
+              <div className="rounded-xl bg-light-purple p-4">
+                {fields.map((field, index) => (
+                  <div key={field.id}>
+                    {index > 0 && <hr className="border-t border-white my-6" />}
+                    <div className="flex items-center justify-between mb-4">
+                      <h4 className="text-2xl font-bold">Milestone {index + 1}</h4>
+                      <Button variant="secondary" size="sm" onClick={() => remove(index)} className="ml-2">
+                        <TrashIcon className="h-4 w-4" />
+                        <span className="hidden sm:inline">Delete milestone</span>
+                      </Button>
+                    </div>
+                    <FormTextarea
+                      label="Description"
+                      showMessageLength
+                      {...getCommonOptions(`milestones.${index}.description`)}
+                    />
+                    <FormTextarea
+                      label="Detail of Deliverables"
+                      showMessageLength
+                      {...getCommonOptions(`milestones.${index}.proposedDeliverables`)}
+                    />
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-x-16 sm:gap-y-1">
+                      <FormSelect
+                        label="Requested Funds (in ETH)"
+                        options={["0.25", "0.5", "1", "2"]}
+                        {...getCommonOptions(`milestones.${index}.requestedAmount`)}
+                      />
+                    </div>
+                  </div>
+                ))}
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-x-16 sm:gap-y-1">
+                <div className="pt-6">
+                  <label className="text-xl font-bold">
+                    Total requested funds:
+                    <span className="bg-light-purple ml-2 p-1 rounded">
+                      {isNaN(totalAmount) ? "-" : totalAmount.toLocaleString()} ETH
+                    </span>
+                  </label>
+                </div>
+                <Button
+                  type="button"
+                  onClick={() =>
+                    append({
+                      description: "",
+                      proposedDeliverables: "",
+                      requestedAmount: "0",
+                    })
+                  }
+                  variant="purple-secondary"
+                  className="mt-4"
+                >
+                  + Add Milestone
+                </Button>
+              </div>
+            </div>
+
+            <hr className="h-1 bg-white mt-4 mb-4" />
+
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-x-16 sm:gap-y-1">
-              <FormSelect
-                label="Requested Funds (in ETH)"
-                options={["0.25", "0.5", "1", "2"]}
-                {...getCommonOptions("requestedFunds")}
-              />
               <FormInput label="Showcase Video Url" {...getCommonOptions("showcaseVideoUrl")} />
               <FormInput label="Github" {...getCommonOptions("github")} />
               <FormInput label="Email address" {...getCommonOptions("email")} />

--- a/packages/nextjs/app/apply/page.tsx
+++ b/packages/nextjs/app/apply/page.tsx
@@ -162,10 +162,13 @@ const Apply: NextPage = () => {
                 <div className="pt-6">
                   <label className="text-xl font-bold">
                     Total requested funds:
-                    <span className="bg-light-purple ml-2 p-1 rounded">
+                    <span className={`bg-light-purple ml-2 p-1 rounded ${totalAmount > 2 ? "text-red-500" : ""}`}>
                       {isNaN(totalAmount) ? "-" : totalAmount.toLocaleString()} ETH
                     </span>
                   </label>
+                  {totalAmount > 2 && (
+                    <p className="mb-0 mt-1 text-red-500">Note: Total requested funds should not exceed 2 ETH.</p>
+                  )}
                 </div>
                 <Button
                   type="button"
@@ -206,7 +209,7 @@ const Apply: NextPage = () => {
                 Connect wallet
               </Button>
             ) : (
-              <Button type="submit" disabled={isPostingNewGrant} className="mt-4 self-center ">
+              <Button type="submit" disabled={isPostingNewGrant || totalAmount > 2} className="mt-4 self-center ">
                 {isPostingNewGrant && <span className="loading loading-spinner"></span>}
                 Submit
               </Button>

--- a/packages/nextjs/app/apply/schema.ts
+++ b/packages/nextjs/app/apply/schema.ts
@@ -1,12 +1,20 @@
 import * as z from "zod";
 import { DEFAULT_INPUT_MAX_LENGTH, DEFAULT_TEXTAREA_MAX_LENGTH } from "~~/utils/forms";
 
+export const milestoneSchema = z.object({
+  description: z.string().min(20, { message: "At least 20 characters required" }).max(DEFAULT_TEXTAREA_MAX_LENGTH),
+  proposedDeliverables: z
+    .string()
+    .min(20, { message: "At least 20 characters required" })
+    .max(DEFAULT_TEXTAREA_MAX_LENGTH),
+  requestedAmount: z.string().max(DEFAULT_INPUT_MAX_LENGTH),
+});
+
 export const applyFormSchema = z.object({
   title: z.string().min(1, { message: "Required" }).max(DEFAULT_INPUT_MAX_LENGTH),
   description: z.string().min(20, { message: "At least 20 characters required" }).max(DEFAULT_TEXTAREA_MAX_LENGTH),
-  milestones: z.string().min(20, { message: "At least 20 characters required" }).max(DEFAULT_TEXTAREA_MAX_LENGTH),
+  milestones: z.array(milestoneSchema),
   showcaseVideoUrl: z.string().max(DEFAULT_INPUT_MAX_LENGTH).optional(),
-  requestedFunds: z.string().max(DEFAULT_INPUT_MAX_LENGTH),
   github: z.string().min(1, { message: "Required" }).max(DEFAULT_INPUT_MAX_LENGTH),
   email: z.string().email().max(DEFAULT_INPUT_MAX_LENGTH),
   twitter: z.string().min(1, { message: "Required" }).max(DEFAULT_INPUT_MAX_LENGTH),

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/index.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/index.tsx
@@ -19,7 +19,7 @@ import { getBlockExplorerAddressLink } from "~~/utils/scaffold-eth";
  */
 export const RainbowKitCustomConnectButton = () => {
   const { targetNetwork } = useTargetNetwork();
-  const { address } = useAccount();
+  const { address, isConnected } = useAccount();
   const { disconnect } = useDisconnect();
   const router = useRouter();
   const { address: sessionAddress, isAuthenticated } = useAuthSession();
@@ -31,11 +31,11 @@ export const RainbowKitCustomConnectButton = () => {
   }, [router, isAuthenticated]);
 
   useEffect(() => {
-    if (sessionAddress && sessionAddress !== address) {
+    if (isConnected && sessionAddress && sessionAddress !== address) {
+      signOut();
       disconnect();
-      signOut({ redirect: true, callbackUrl: "/" });
     }
-  }, [address, disconnect, sessionAddress]);
+  }, [address, disconnect, isConnected, sessionAddress]);
 
   return (
     <ConnectButton.Custom>

--- a/packages/nextjs/services/database/migrations/0004_giant_blade.sql
+++ b/packages/nextjs/services/database/migrations/0004_giant_blade.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS "milestones" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"milestone_number" integer DEFAULT 1 NOT NULL,
+	"stage_id" integer NOT NULL,
+	"description" text NOT NULL,
+	"proposed_deliverables" text NOT NULL,
+	"completion_proof" text,
+	"completed_at" timestamp,
+	"requested_amount" bigint NOT NULL,
+	"granted_amount" bigint,
+	"status" "milestones_status" DEFAULT 'proposed' NOT NULL,
+	"statusNote" text,
+	"payment_tx" varchar(66),
+	"paid_at" timestamp
+);
+--> statement-breakpoint
+ALTER TABLE "grants" ALTER COLUMN "milestones" DROP NOT NULL;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "milestones" ADD CONSTRAINT "milestones_stage_id_stages_id_fk" FOREIGN KEY ("stage_id") REFERENCES "public"."stages"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/packages/nextjs/services/database/migrations/meta/0004_snapshot.json
+++ b/packages/nextjs/services/database/migrations/meta/0004_snapshot.json
@@ -1,0 +1,1165 @@
+{
+  "id": "a9c072cd-70db-44a0-b25f-01e83179241b",
+  "prevId": "5f6efad1-6ffe-4bf4-af34-2890a4c7ac07",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.approval_votes": {
+      "name": "approval_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voted_at": {
+          "name": "voted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_address": {
+          "name": "author_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "approval_votes_stage_id_stages_id_fk": {
+          "name": "approval_votes_stage_id_stages_id_fk",
+          "tableFrom": "approval_votes",
+          "tableTo": "stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "approval_votes_author_address_users_address_fk": {
+          "name": "approval_votes_author_address_users_address_fk",
+          "tableFrom": "approval_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_address"
+          ],
+          "columnsTo": [
+            "address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "approval_votes_stage_id_author_address_unique": {
+          "name": "approval_votes_stage_id_author_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stage_id",
+            "author_address"
+          ]
+        }
+      }
+    },
+    "public.grants": {
+      "name": "grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "grant_number": {
+          "name": "grant_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "milestones": {
+          "name": "milestones",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "showcaseVideoUrl": {
+          "name": "showcaseVideoUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestedFunds": {
+          "name": "requestedFunds",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github": {
+          "name": "github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "twitter": {
+          "name": "twitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram": {
+          "name": "telegram",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submited_at": {
+          "name": "submited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "builder_address": {
+          "name": "builder_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "grants_builder_address_users_address_fk": {
+          "name": "grants_builder_address_users_address_fk",
+          "tableFrom": "grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "builder_address"
+          ],
+          "columnsTo": [
+            "address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.large_approval_votes": {
+      "name": "large_approval_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "voted_at": {
+          "name": "voted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_address": {
+          "name": "author_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "large_approval_votes_stage_id_large_stages_id_fk": {
+          "name": "large_approval_votes_stage_id_large_stages_id_fk",
+          "tableFrom": "large_approval_votes",
+          "tableTo": "large_stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "large_approval_votes_author_address_users_address_fk": {
+          "name": "large_approval_votes_author_address_users_address_fk",
+          "tableFrom": "large_approval_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_address"
+          ],
+          "columnsTo": [
+            "address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "large_approval_votes_stage_id_author_address_unique": {
+          "name": "large_approval_votes_stage_id_author_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stage_id",
+            "author_address"
+          ]
+        }
+      }
+    },
+    "public.large_grants": {
+      "name": "large_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "showcaseVideoUrl": {
+          "name": "showcaseVideoUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "twitter": {
+          "name": "twitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram": {
+          "name": "telegram",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submited_at": {
+          "name": "submited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "builder_address": {
+          "name": "builder_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "large_grants_builder_address_users_address_fk": {
+          "name": "large_grants_builder_address_users_address_fk",
+          "tableFrom": "large_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "builder_address"
+          ],
+          "columnsTo": [
+            "address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.large_milestone_private_notes": {
+      "name": "large_milestone_private_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "written_at": {
+          "name": "written_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "milestone_id": {
+          "name": "milestone_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_address": {
+          "name": "author_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "large_milestone_private_notes_milestone_id_large_milestones_id_fk": {
+          "name": "large_milestone_private_notes_milestone_id_large_milestones_id_fk",
+          "tableFrom": "large_milestone_private_notes",
+          "tableTo": "large_milestones",
+          "columnsFrom": [
+            "milestone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "large_milestone_private_notes_author_address_users_address_fk": {
+          "name": "large_milestone_private_notes_author_address_users_address_fk",
+          "tableFrom": "large_milestone_private_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_address"
+          ],
+          "columnsTo": [
+            "address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.large_milestones": {
+      "name": "large_milestones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "milestone_number": {
+          "name": "milestone_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_deliverables": {
+          "name": "proposed_deliverables",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_completion_date": {
+          "name": "proposed_completion_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completion_proof": {
+          "name": "completion_proof",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "milestones_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'proposed'"
+        },
+        "statusNote": {
+          "name": "statusNote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_tx": {
+          "name": "verified_tx",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_by": {
+          "name": "verified_by",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_tx": {
+          "name": "payment_tx",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_by": {
+          "name": "paid_by",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "large_milestones_stage_id_large_stages_id_fk": {
+          "name": "large_milestones_stage_id_large_stages_id_fk",
+          "tableFrom": "large_milestones",
+          "tableTo": "large_stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.large_private_notes": {
+      "name": "large_private_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "written_at": {
+          "name": "written_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_address": {
+          "name": "author_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "large_private_notes_stage_id_large_stages_id_fk": {
+          "name": "large_private_notes_stage_id_large_stages_id_fk",
+          "tableFrom": "large_private_notes",
+          "tableTo": "large_stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "large_private_notes_author_address_users_address_fk": {
+          "name": "large_private_notes_author_address_users_address_fk",
+          "tableFrom": "large_private_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_address"
+          ],
+          "columnsTo": [
+            "address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.large_reject_votes": {
+      "name": "large_reject_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "voted_at": {
+          "name": "voted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_address": {
+          "name": "author_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "large_reject_votes_stage_id_large_stages_id_fk": {
+          "name": "large_reject_votes_stage_id_large_stages_id_fk",
+          "tableFrom": "large_reject_votes",
+          "tableTo": "large_stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "large_reject_votes_author_address_users_address_fk": {
+          "name": "large_reject_votes_author_address_users_address_fk",
+          "tableFrom": "large_reject_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_address"
+          ],
+          "columnsTo": [
+            "address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "large_reject_votes_stage_id_author_address_unique": {
+          "name": "large_reject_votes_stage_id_author_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stage_id",
+            "author_address"
+          ]
+        }
+      }
+    },
+    "public.large_stages": {
+      "name": "large_stages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stage_number": {
+          "name": "stage_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "submited_at": {
+          "name": "submited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "grant_id": {
+          "name": "grant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "stage_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'proposed'"
+        },
+        "statusNote": {
+          "name": "statusNote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_tx": {
+          "name": "approved_tx",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "large_stages_grant_id_large_grants_id_fk": {
+          "name": "large_stages_grant_id_large_grants_id_fk",
+          "tableFrom": "large_stages",
+          "tableTo": "large_grants",
+          "columnsFrom": [
+            "grant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.milestones": {
+      "name": "milestones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "milestone_number": {
+          "name": "milestone_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_deliverables": {
+          "name": "proposed_deliverables",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completion_proof": {
+          "name": "completion_proof",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_amount": {
+          "name": "requested_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_amount": {
+          "name": "granted_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "milestones_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'proposed'"
+        },
+        "statusNote": {
+          "name": "statusNote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_tx": {
+          "name": "payment_tx",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "milestones_stage_id_stages_id_fk": {
+          "name": "milestones_stage_id_stages_id_fk",
+          "tableFrom": "milestones",
+          "tableTo": "stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.private_notes": {
+      "name": "private_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "written_at": {
+          "name": "written_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_address": {
+          "name": "author_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "private_notes_stage_id_stages_id_fk": {
+          "name": "private_notes_stage_id_stages_id_fk",
+          "tableFrom": "private_notes",
+          "tableTo": "stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "private_notes_author_address_users_address_fk": {
+          "name": "private_notes_author_address_users_address_fk",
+          "tableFrom": "private_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_address"
+          ],
+          "columnsTo": [
+            "address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.reject_votes": {
+      "name": "reject_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "voted_at": {
+          "name": "voted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_address": {
+          "name": "author_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reject_votes_stage_id_stages_id_fk": {
+          "name": "reject_votes_stage_id_stages_id_fk",
+          "tableFrom": "reject_votes",
+          "tableTo": "stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "reject_votes_author_address_users_address_fk": {
+          "name": "reject_votes_author_address_users_address_fk",
+          "tableFrom": "reject_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_address"
+          ],
+          "columnsTo": [
+            "address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reject_votes_stage_id_author_address_unique": {
+          "name": "reject_votes_stage_id_author_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stage_id",
+            "author_address"
+          ]
+        }
+      }
+    },
+    "public.stages": {
+      "name": "stages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stage_number": {
+          "name": "stage_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "milestone": {
+          "name": "milestone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submited_at": {
+          "name": "submited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "grant_id": {
+          "name": "grant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantAmount": {
+          "name": "grantAmount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "stage_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'proposed'"
+        },
+        "statusNote": {
+          "name": "statusNote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_tx": {
+          "name": "approved_tx",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stages_grant_id_grants_id_fk": {
+          "name": "stages_grant_id_grants_id_fk",
+          "tableFrom": "stages",
+          "tableTo": "grants",
+          "columnsFrom": [
+            "grant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'grantee'"
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_address_unique": {
+          "name": "users_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "public.milestones_status": {
+      "name": "milestones_status",
+      "schema": "public",
+      "values": [
+        "proposed",
+        "approved",
+        "completed",
+        "verified",
+        "paid",
+        "rejected"
+      ]
+    },
+    "public.stage_status": {
+      "name": "stage_status",
+      "schema": "public",
+      "values": [
+        "proposed",
+        "approved",
+        "completed",
+        "rejected"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "grantee"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/nextjs/services/database/migrations/meta/_journal.json
+++ b/packages/nextjs/services/database/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1749151557717,
       "tag": "0003_opposite_lord_tyger",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1749590891068,
+      "tag": "0004_giant_blade",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/nextjs/services/database/repositories/grants.ts
+++ b/packages/nextjs/services/database/repositories/grants.ts
@@ -1,8 +1,11 @@
 import { InferInsertModel, InferSelectModel, desc, eq, max } from "drizzle-orm";
 import { db } from "~~/services/database/config/postgresClient";
-import { grants, stages } from "~~/services/database/config/schema";
+import { grants, milestones, stages } from "~~/services/database/config/schema";
 
 export type GrantInsert = InferInsertModel<typeof grants>;
+export type GrantInsertWithMilestones = Omit<GrantInsert, "milestones"> & {
+  milestones: Omit<InferInsertModel<typeof milestones>, "stageId" | "milestoneNumber">[];
+};
 export type Grant = InferSelectModel<typeof grants>;
 export type PublicGrant = Awaited<ReturnType<typeof getPublicGrants>>[number];
 
@@ -77,19 +80,46 @@ export async function getBuilderGrants(builderAddress: string) {
   });
 }
 
-export async function createGrant(grant: GrantInsert) {
-  const maxGrantNumber = await db
-    .select({ maxNumber: max(grants.grantNumber) })
-    .from(grants)
-    .where(eq(grants.builderAddress, grant.builderAddress))
-    .then(result => result[0]?.maxNumber ?? 0);
+export async function createGrant(
+  grant: GrantInsertWithMilestones,
+): Promise<{ grantId: number; stageId: number; createdMilestones: number[] }> {
+  return await db.transaction(async tx => {
+    const maxGrantNumber = await db
+      .select({ maxNumber: max(grants.grantNumber) })
+      .from(grants)
+      .where(eq(grants.builderAddress, grant.builderAddress))
+      .then(result => result[0]?.maxNumber ?? 0);
 
-  const newGrantNumber = maxGrantNumber + 1;
+    const newGrantNumber = maxGrantNumber + 1;
 
-  return await db
-    .insert(grants)
-    .values({ ...grant, grantNumber: newGrantNumber })
-    .returning({ id: grants.id, grantNumber: grants.grantNumber });
+    const [createdGrant] = await tx
+      .insert(grants)
+      .values({ ...grant, grantNumber: newGrantNumber, milestones: undefined })
+      .returning({ id: grants.id, grantNumber: grants.grantNumber });
+    const [createdStage] = await tx.insert(stages).values({ grantId: createdGrant.id }).returning({ id: stages.id });
+
+    const createdMilestones = [];
+
+    for (let i = 0; i < grant.milestones.length; i++) {
+      const milestone = grant.milestones[i];
+      const [createdMilestone] = await tx
+        .insert(milestones)
+        .values({
+          ...milestone,
+          stageId: createdStage.id,
+          milestoneNumber: i + 1,
+        })
+        .returning({ id: milestones.id });
+      createdMilestones.push(createdMilestone.id);
+    }
+
+    return {
+      grantId: createdGrant.id,
+      grantNumber: createdGrant.grantNumber,
+      stageId: createdStage.id,
+      createdMilestones,
+    };
+  });
 }
 
 export async function getGrantById(grantId: number) {


### PR DESCRIPTION
- Changed schema, adding milestones to ETH grant stages.
- Changed apply page to allow setting milestones data (similar to USDC grants)
- Changed backend endpoint to save the grant data with the new milestones.

This branch is to be merged to the new eth-grants-improvements, where we will be adding all new improvements to ETH grants before merging it to main.

![localhost_3000_apply](https://github.com/user-attachments/assets/16b74c0b-6c3d-4903-990b-1a03deaa9965)

closes #117 