### PR TITLE
Revert "fix: session"

### DIFF
--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/index.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/index.tsx
@@ -19,7 +19,7 @@ import { getBlockExplorerAddressLink } from "~~/utils/scaffold-eth";
  */
 export const RainbowKitCustomConnectButton = () => {
   const { targetNetwork } = useTargetNetwork();
-  const { address } = useAccount();
+  const { address, isConnected } = useAccount();
   const { disconnect } = useDisconnect();
   const router = useRouter();
   const { address: sessionAddress, isAuthenticated } = useAuthSession();
@@ -31,11 +31,11 @@ export const RainbowKitCustomConnectButton = () => {
   }, [router, isAuthenticated]);
 
   useEffect(() => {
-    if (sessionAddress && sessionAddress !== address) {
+    if (isConnected && sessionAddress && sessionAddress !== address) {
+      signOut();
       disconnect();
-      signOut({ redirect: true, callbackUrl: "/" });
     }
-  }, [address, disconnect, sessionAddress]);
+  }, [address, disconnect, isConnected, sessionAddress]);
 
   return (
     <ConnectButton.Custom>


### PR DESCRIPTION
Reverts BuidlGuidl/ens-pg#55

We are experiencing random connection loses when opening new tabs via "View grants" and with the session changes it was affecting to all the other tabs. Tested reverting these changes and the UX is good even if you lost the connection on the new tab.