### PR TITLE
Withdraw from ETH grant milestones

### DIFF
--- a/packages/nextjs/app/api/milestones/[milestoneId]/complete/route.ts
+++ b/packages/nextjs/app/api/milestones/[milestoneId]/complete/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import {
+  MilestoneUpdate,
+  getMilestoneByIdWithRelatedData,
+  updateMilestoneStatusToPaid,
+} from "~~/services/database/repositories/milestones";
+import { getStageWithMilestones, updateStageStatusToCompleted } from "~~/services/database/repositories/stages";
+import { notifyTelegramBot } from "~~/services/notifications/telegram";
+import { authOptions } from "~~/utils/auth";
+
+export type CompleteMilestoneBody = {
+  paymentTx: MilestoneUpdate["paymentTx"];
+  completionProof: MilestoneUpdate["completionProof"];
+};
+
+export async function POST(req: NextRequest, { params }: { params: { milestoneId: string } }) {
+  try {
+    const { milestoneId } = params;
+    const body = (await req.json()) as CompleteMilestoneBody;
+    const session = await getServerSession(authOptions);
+    const milestone = await getMilestoneByIdWithRelatedData(Number(milestoneId));
+
+    if (!milestone) return NextResponse.json({ error: "Milestone not found" }, { status: 404 });
+
+    if (session?.user.address !== milestone.stage.grant.builderAddress) {
+      return NextResponse.json({ error: "Only grant owner can complete milestones" }, { status: 401 });
+    }
+
+    if (!body.paymentTx || !body.completionProof) {
+      return NextResponse.json({ error: "Payment transaction and completion proof are required" }, { status: 400 });
+    }
+
+    await updateMilestoneStatusToPaid({
+      milestoneId: Number(milestoneId),
+      paymentTx: body.paymentTx,
+      completionProof: body.completionProof,
+    });
+
+    // check if this is the last milestone of the stage and update the stage status to "completed"
+    const stage = milestone.stage;
+    const stageWithMilestones = await getStageWithMilestones(stage.id);
+    const allMilestonesCompleted = stageWithMilestones
+      ? stageWithMilestones.milestones.every(m => m.status === "paid")
+      : false;
+
+    if (allMilestonesCompleted) {
+      await updateStageStatusToCompleted(stage.id);
+    }
+
+    // Fetch the updated milestone
+    const updatedMilestone = await getMilestoneByIdWithRelatedData(Number(milestoneId));
+    await notifyTelegramBot("milestone", { milestone: updatedMilestone });
+
+    return NextResponse.json({ milestoneId }, { status: 200 });
+  } catch (e) {
+    return NextResponse.json({ error: "Error processing form" }, { status: 500 });
+  }
+}

--- a/packages/nextjs/app/api/milestones/[milestoneId]/complete/route.ts
+++ b/packages/nextjs/app/api/milestones/[milestoneId]/complete/route.ts
@@ -23,7 +23,11 @@ export async function POST(req: NextRequest, { params }: { params: { milestoneId
 
     if (!milestone) return NextResponse.json({ error: "Milestone not found" }, { status: 404 });
 
-    if (session?.user.address !== milestone.stage.grant.builderAddress) {
+    if (!session) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    if (session.user.address !== milestone.stage.grant.builderAddress) {
       return NextResponse.json({ error: "Only grant owner can complete milestones" }, { status: 401 });
     }
 

--- a/packages/nextjs/app/api/milestones/[milestoneId]/status/route.ts
+++ b/packages/nextjs/app/api/milestones/[milestoneId]/status/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { getMilestoneByIdWithRelatedData } from "~~/services/database/repositories/milestones";
+import { authOptions } from "~~/utils/auth";
+
+export async function GET(_request: Request, { params }: { params: { milestoneId: string } }) {
+  try {
+    const session = await getServerSession(authOptions);
+    const { milestoneId } = params;
+
+    const milestone = await getMilestoneByIdWithRelatedData(Number(milestoneId));
+
+    if (!milestone) {
+      return NextResponse.json({ error: "Milestone not found" }, { status: 404 });
+    }
+
+    if (session?.user?.role !== "admin" && session?.user?.address !== milestone.stage.grant.builderAddress) {
+      return NextResponse.json("Access denied", { status: 403 });
+    }
+
+    return NextResponse.json({ status: milestone.status }, { status: 200 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/packages/nextjs/app/grants/[grantId]/_components/CurrentStage/MilestoneDetail.tsx
+++ b/packages/nextjs/app/grants/[grantId]/_components/CurrentStage/MilestoneDetail.tsx
@@ -6,18 +6,16 @@ import { formatEther } from "viem";
 import { BadgeMilestone } from "~~/components/pg-ens/BadgeMilestone";
 import { Button } from "~~/components/pg-ens/Button";
 import { Milestone } from "~~/services/database/repositories/milestones";
-import { Stage } from "~~/services/database/repositories/stages";
 import { getFormattedDateWithDay } from "~~/utils/getFormattedDate";
 import { multilineStringToTsx } from "~~/utils/multiline-string-to-tsx";
 
 type MilestoneDetailProps = {
   milestone: Milestone;
-  stage: Stage;
   contractGrantId?: bigint;
   refetchContractInfo: () => Promise<any>;
 };
 
-export const MilestoneDetail = ({ milestone, stage, contractGrantId, refetchContractInfo }: MilestoneDetailProps) => {
+export const MilestoneDetail = ({ milestone, contractGrantId, refetchContractInfo }: MilestoneDetailProps) => {
   const withdrawModalRef = useRef<HTMLDialogElement>(null);
 
   return (
@@ -62,9 +60,9 @@ export const MilestoneDetail = ({ milestone, stage, contractGrantId, refetchCont
                     {milestone.status === "rejected" ? "Rejection notes" : "Note"}: {milestone.statusNote}
                   </div>
                 )}
-                {milestone.status === "paid" && milestone.paidAt && (
+                {milestone.status === "paid" && milestone.completedAt && (
                   <div className="mt-2 ml-4 text-sm font-bold text-gray-400">
-                    Paid on {getFormattedDateWithDay(milestone.paidAt)} -
+                    Withdraw on {getFormattedDateWithDay(milestone.completedAt)} -
                     <a
                       href={`https://optimistic.etherscan.io/tx/${milestone.paymentTx}`}
                       target="_blank"
@@ -83,7 +81,7 @@ export const MilestoneDetail = ({ milestone, stage, contractGrantId, refetchCont
 
       <WithdrawModal
         ref={withdrawModalRef}
-        stage={stage}
+        milestone={milestone}
         closeModal={() => withdrawModalRef.current?.close()}
         contractGrantId={contractGrantId}
         refetchContractInfo={refetchContractInfo}

--- a/packages/nextjs/app/grants/[grantId]/_components/CurrentStage/WithdrawModal/index.tsx
+++ b/packages/nextjs/app/grants/[grantId]/_components/CurrentStage/WithdrawModal/index.tsx
@@ -81,12 +81,12 @@ export const WithdrawModal = forwardRef<HTMLDialogElement, WithdrawModalProps>(
             {/* if there is a button in form, it will close the modal */}
             <button className="btn btn-sm btn-circle btn-ghost text-xl h-auto">✕</button>
           </form>
-          <hr className="-mx-6 my-0 border-t border-white" />
-          <div className="-mx-6 px-6 py-4 bg-secondary text-xl font-bold">
-            {multilineStringToTsx(milestone.description)}
-          </div>
           <FormProvider {...formMethods}>
             <form onSubmit={handleSubmit(onSubmit)} className="w-full flex flex-col space-y-1 mt-4">
+              <div className="text-xl">
+                <span className="font-bold">Description:</span>
+                <p className="mt-1">{multilineStringToTsx(milestone.description)}</p>
+              </div>
               <div className="text-xl">
                 <span className="font-bold">Amount:</span>
                 <p className="mt-1">{formatEther(milestone.grantedAmount || 0n)} ETH</p>

--- a/packages/nextjs/app/grants/[grantId]/_components/CurrentStage/WithdrawModal/index.tsx
+++ b/packages/nextjs/app/grants/[grantId]/_components/CurrentStage/WithdrawModal/index.tsx
@@ -1,27 +1,29 @@
 import { forwardRef } from "react";
 import { useRouter } from "next/navigation";
 import { WithdrawModalFormValues, withdrawModalFormSchema } from "./schema";
+import { useMutation } from "@tanstack/react-query";
 import { FormProvider } from "react-hook-form";
 import { Toaster } from "react-hot-toast";
-import { parseEther } from "viem";
+import { formatEther } from "viem";
 import { apolloClient } from "~~/components/ScaffoldEthAppWithProviders";
 import { Button } from "~~/components/pg-ens/Button";
-import { FormInput } from "~~/components/pg-ens/form-fields/FormInput";
 import { FormTextarea } from "~~/components/pg-ens/form-fields/FormTextarea";
 import { useFormMethods } from "~~/hooks/pg-ens/useFormMethods";
 import { useScaffoldWriteContract } from "~~/hooks/scaffold-eth";
-import { Stage } from "~~/services/database/repositories/stages";
+import { Milestone } from "~~/services/database/repositories/milestones";
+import { multilineStringToTsx } from "~~/utils/multiline-string-to-tsx";
+import { postMutationFetcher } from "~~/utils/react-query";
 import { getParsedError, notification } from "~~/utils/scaffold-eth";
 
 type WithdrawModalProps = {
-  stage: Stage;
+  milestone: Milestone;
   closeModal: () => void;
   contractGrantId?: bigint;
   refetchContractInfo: () => Promise<any>;
 };
 
 export const WithdrawModal = forwardRef<HTMLDialogElement, WithdrawModalProps>(
-  ({ closeModal, contractGrantId, refetchContractInfo }, ref) => {
+  ({ milestone, closeModal, contractGrantId, refetchContractInfo }, ref) => {
     const router = useRouter();
 
     const { formMethods, getCommonOptions } = useFormMethods<WithdrawModalFormValues>({
@@ -31,14 +33,24 @@ export const WithdrawModal = forwardRef<HTMLDialogElement, WithdrawModalProps>(
 
     const { writeContractAsync, isPending: isWritingWithOnChain } = useScaffoldWriteContract("Stream");
 
+    const { mutateAsync: postCompleteMilestone, isPending: isPostingCompleteMilestone } = useMutation({
+      mutationFn: (completionData: { paymentTx: string; completionProof: string }) =>
+        postMutationFetcher(`/api/milestones/${milestone.id}/complete`, { body: completionData }),
+    });
+
     const onSubmit = async (fieldValues: WithdrawModalFormValues) => {
       let txnHash: string | undefined;
       try {
-        const { completedMilestones, withdrawAmount } = fieldValues;
+        const { completionProof } = fieldValues;
 
         txnHash = await writeContractAsync({
           functionName: "streamWithdraw",
-          args: [contractGrantId, parseEther(withdrawAmount), completedMilestones],
+          args: [contractGrantId, milestone.grantedAmount || 0n, completionProof],
+        });
+
+        await postCompleteMilestone({
+          paymentTx: txnHash || "",
+          completionProof,
         });
 
         await apolloClient.refetchQueries({
@@ -61,29 +73,42 @@ export const WithdrawModal = forwardRef<HTMLDialogElement, WithdrawModalProps>(
 
     return (
       <dialog id="action_modal" className="modal" ref={ref}>
-        <div className="modal-box flex flex-col space-y-3">
+        <div className="modal-box flex flex-col">
           <form method="dialog" className="bg-secondary -mx-6 -mt-6 px-6 py-4 flex items-center justify-between">
             <div className="flex justify-between items-center">
-              <p className="font-bold text-xl m-0">Withdraw a milestone</p>
+              <p className="font-bold text-xl m-0">Withdraw Milestone {milestone.milestoneNumber}</p>
             </div>
             {/* if there is a button in form, it will close the modal */}
             <button className="btn btn-sm btn-circle btn-ghost text-xl h-auto">✕</button>
           </form>
+          <hr className="-mx-6 my-0 border-t border-white" />
+          <div className="-mx-6 px-6 py-4 bg-secondary text-xl font-bold">
+            {multilineStringToTsx(milestone.description)}
+          </div>
           <FormProvider {...formMethods}>
-            <form onSubmit={handleSubmit(onSubmit)} className="w-full flex flex-col space-y-1">
-              <FormInput label="Amount (in ETH)" {...getCommonOptions("withdrawAmount")} />
+            <form onSubmit={handleSubmit(onSubmit)} className="w-full flex flex-col space-y-1 mt-4">
+              <div className="text-xl">
+                <span className="font-bold">Amount:</span>
+                <p className="mt-1">{formatEther(milestone.grantedAmount || 0n)} ETH</p>
+              </div>
+              <div>
+                <span className="text-xl font-bold">Detail of Deliverables:</span>
+                <p className="text-lg mt-1">{multilineStringToTsx(milestone.proposedDeliverables)}</p>
+              </div>
               <div className="flex flex-col">
-                <FormTextarea
-                  label="Completed Milestone and proof of completion"
-                  showMessageLength
-                  {...getCommonOptions("completedMilestones")}
-                />
+                <FormTextarea label="Proof of completion" showMessageLength {...getCommonOptions("completionProof")} />
                 <span className="text-sm italic text-right pb-4">
                   *Video walkthrough, GitHub repo or other deliverables
                 </span>
               </div>
-              <Button type="submit" disabled={isWritingWithOnChain} className="self-center">
-                {isWritingWithOnChain && <span className="loading loading-spinner"></span>}
+              <Button
+                type="submit"
+                disabled={isWritingWithOnChain || isPostingCompleteMilestone}
+                className="self-center"
+              >
+                {(isWritingWithOnChain || isPostingCompleteMilestone) && (
+                  <span className="loading loading-spinner"></span>
+                )}
                 Withdraw
               </Button>
             </form>

--- a/packages/nextjs/app/grants/[grantId]/_components/CurrentStage/WithdrawModal/schema.tsx
+++ b/packages/nextjs/app/grants/[grantId]/_components/CurrentStage/WithdrawModal/schema.tsx
@@ -2,14 +2,7 @@ import * as z from "zod";
 import { DEFAULT_TEXTAREA_MAX_LENGTH } from "~~/utils/forms";
 
 export const withdrawModalFormSchema = z.object({
-  // TODO: get possible amount from contract
-  withdrawAmount: z.string().refine(val => Number(val) > 0, {
-    message: "Enter valid number",
-  }),
-  completedMilestones: z
-    .string()
-    .min(20, { message: "At least 20 characters required" })
-    .max(DEFAULT_TEXTAREA_MAX_LENGTH),
+  completionProof: z.string().min(20, { message: "At least 20 characters required" }).max(DEFAULT_TEXTAREA_MAX_LENGTH),
 });
 
 export type WithdrawModalFormValues = z.infer<typeof withdrawModalFormSchema>;

--- a/packages/nextjs/app/grants/[grantId]/_components/CurrentStage/index.tsx
+++ b/packages/nextjs/app/grants/[grantId]/_components/CurrentStage/index.tsx
@@ -4,7 +4,6 @@ import { useRef } from "react";
 import { GrantWithStages } from "../../page";
 import { MilestoneDetail } from "./MilestoneDetail";
 import { NewStageModal } from "./NewStageModal";
-import { WithdrawModal } from "./WithdrawModal";
 import { formatEther } from "viem";
 import { Badge } from "~~/components/pg-ens/Badge";
 import { Button } from "~~/components/pg-ens/Button";
@@ -25,33 +24,22 @@ export const CurrentStage = ({ grant }: CurrentStageProps) => {
     args: [grant.builderAddress, BigInt(grant.grantNumber)],
   });
 
-  const {
-    data: contractGrantInfo,
-    isLoading: isBuilderInfoLoading,
-    refetch: refetchGrantInfo,
-  } = useScaffoldReadContract({
+  const { data: contractGrantInfo, refetch: refetchGrantInfo } = useScaffoldReadContract({
     contractName: "Stream",
     functionName: "grantStreams",
     args: [contractGrantId],
   });
 
-  const {
-    data: unlockedAmount,
-    isLoading: isUnlockedAmountLoading,
-    refetch: refetchUnlockedAmount,
-  } = useScaffoldReadContract({
+  const { data: unlockedAmount, refetch: refetchUnlockedAmount } = useScaffoldReadContract({
     contractName: "Stream",
     functionName: "unlockedGrantAmount",
     args: [contractGrantId],
   });
 
-  const isBtnLoading = isBuilderInfoLoading || isUnlockedAmountLoading;
-
   const [cap = BigInt(0), , amountLeft = BigInt(0)] = contractGrantInfo ?? [];
   const amountWithdrawn = cap - amountLeft;
 
   const newStageModalRef = useRef<HTMLDialogElement>(null);
-  const withdrawModalRef = useRef<HTMLDialogElement>(null);
 
   return (
     <div className="w-full max-w-5xl">
@@ -61,15 +49,12 @@ export const CurrentStage = ({ grant }: CurrentStageProps) => {
       </div>
       {(latestStage.status === "approved" || latestStage.status === "completed") && (
         <div className="bg-white px-4 sm:px-12 py-4 sm:py-10 mt-6 flex flex-col sm:flex-row gap-4 justify-between items-center rounded-xl">
-          {(contractGrantInfo && amountLeft === BigInt(0)) || latestStage.status === "completed" ? (
-            <Button onClick={() => newStageModalRef && newStageModalRef.current?.showModal()}>
-              Apply for new stage
-            </Button>
-          ) : (
-            <Button disabled={isBtnLoading} onClick={() => withdrawModalRef && withdrawModalRef.current?.showModal()}>
-              Withdraw milestone
-            </Button>
-          )}
+          {(contractGrantInfo && amountLeft === BigInt(0)) ||
+            (latestStage.status === "completed" && (
+              <Button onClick={() => newStageModalRef && newStageModalRef.current?.showModal()}>
+                Apply for new stage
+              </Button>
+            ))}
 
           <GrantProgressBar
             className="w-full sm:w-1/2"
@@ -84,7 +69,6 @@ export const CurrentStage = ({ grant }: CurrentStageProps) => {
         <MilestoneDetail
           milestone={milestone}
           key={milestone.id}
-          stage={latestStage}
           contractGrantId={contractGrantId}
           refetchContractInfo={async () => {
             await Promise.all([refetchGrantInfo(), refetchUnlockedAmount()]);
@@ -97,16 +81,6 @@ export const CurrentStage = ({ grant }: CurrentStageProps) => {
         previousStage={latestStage}
         grantId={grant.id}
         closeModal={() => newStageModalRef.current?.close()}
-      />
-
-      <WithdrawModal
-        ref={withdrawModalRef}
-        stage={latestStage}
-        closeModal={() => withdrawModalRef.current?.close()}
-        contractGrantId={contractGrantId}
-        refetchContractInfo={async () => {
-          await Promise.all([refetchGrantInfo(), refetchUnlockedAmount()]);
-        }}
       />
     </div>
   );

--- a/packages/nextjs/app/grants/[grantId]/_components/CurrentStage/index.tsx
+++ b/packages/nextjs/app/grants/[grantId]/_components/CurrentStage/index.tsx
@@ -49,12 +49,11 @@ export const CurrentStage = ({ grant }: CurrentStageProps) => {
       </div>
       {(latestStage.status === "approved" || latestStage.status === "completed") && (
         <div className="bg-white px-4 sm:px-12 py-4 sm:py-10 mt-6 flex flex-col sm:flex-row gap-4 justify-between items-center rounded-xl">
-          {(contractGrantInfo && amountLeft === BigInt(0)) ||
-            (latestStage.status === "completed" && (
-              <Button onClick={() => newStageModalRef && newStageModalRef.current?.showModal()}>
-                Apply for new stage
-              </Button>
-            ))}
+          {((contractGrantInfo && amountLeft === BigInt(0)) || latestStage.status === "completed") && (
+            <Button onClick={() => newStageModalRef && newStageModalRef.current?.showModal()}>
+              Apply for new stage
+            </Button>
+          )}
 
           <GrantProgressBar
             className={`w-full ${

--- a/packages/nextjs/app/grants/[grantId]/_components/CurrentStage/index.tsx
+++ b/packages/nextjs/app/grants/[grantId]/_components/CurrentStage/index.tsx
@@ -57,7 +57,9 @@ export const CurrentStage = ({ grant }: CurrentStageProps) => {
             ))}
 
           <GrantProgressBar
-            className="w-full sm:w-1/2"
+            className={`w-full ${
+              (contractGrantInfo && amountLeft === BigInt(0)) || latestStage.status === "completed" ? "sm:w-1/2" : ""
+            }`}
             amount={Number(formatEther(cap))}
             withdrawn={Number(formatEther(amountWithdrawn as unknown as bigint))}
             available={Number(formatEther(unlockedAmount ?? BigInt(0)))}

--- a/packages/nextjs/app/grants/[grantId]/_components/ProjectTimeline/TimelineStage.tsx
+++ b/packages/nextjs/app/grants/[grantId]/_components/ProjectTimeline/TimelineStage.tsx
@@ -85,7 +85,7 @@ export const TimelineStage = ({ stage, grant }: TimelineStageProps) => {
               </div>
             )}
 
-            {stage.milestones && (
+            {stage.milestones ? (
               <div className="mt-4">
                 {stage.milestones.map((milestone, idx) => (
                   <div key={`milestone-${milestone.id}`} className="mt-2">
@@ -112,17 +112,17 @@ export const TimelineStage = ({ stage, grant }: TimelineStageProps) => {
                   </div>
                 ))}
               </div>
-            )}
+            ) : (
+              withdrawals.map((withdrawal, idx) => (
+                <div key={`withdrawal-${withdrawal.id}`} className="mt-3 text-gray-500">
+                  <div className="font-bold text-lg">
+                    Milestone {idx + 1} ({formatEther(BigInt(withdrawal.amount))} Eth withdraw)
+                  </div>
 
-            {withdrawals.map((withdrawal, idx) => (
-              <div key={`withdrawal-${withdrawal.id}`} className="mt-3 text-gray-500">
-                <div className="font-bold text-lg">
-                  Milestone {idx + 1} ({formatEther(BigInt(withdrawal.amount))} Eth withdraw)
+                  {multilineStringToTsx(withdrawal.reason || "-")}
                 </div>
-
-                {multilineStringToTsx(withdrawal.reason || "-")}
-              </div>
-            ))}
+              ))
+            )}
           </>
         ) : (
           <div className="font-bold text-2xl -mt-1.5 text-gray-500">Stage {stage.stageNumber} (locked)</div>

--- a/packages/nextjs/services/database/config/schema.ts
+++ b/packages/nextjs/services/database/config/schema.ts
@@ -71,7 +71,6 @@ export const milestones = pgTable("milestones", {
   status: milestonesStatusEnum("status").notNull().default("proposed"),
   statusNote: text("statusNote"),
   paymentTx: varchar("payment_tx", { length: 66 }),
-  paidAt: timestamp("paid_at"),
 });
 
 export const milestonesRelations = relations(milestones, ({ one }) => ({

--- a/packages/nextjs/services/database/migrations/0006_known_wrecker.sql
+++ b/packages/nextjs/services/database/migrations/0006_known_wrecker.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "milestones" DROP COLUMN IF EXISTS "paid_at";

--- a/packages/nextjs/services/database/migrations/meta/0006_snapshot.json
+++ b/packages/nextjs/services/database/migrations/meta/0006_snapshot.json
@@ -1,0 +1,1159 @@
+{
+  "id": "dd637e30-a392-4a93-aa00-e11c750bff92",
+  "prevId": "44d62651-bb25-40a5-8885-90e747adb317",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.approval_votes": {
+      "name": "approval_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voted_at": {
+          "name": "voted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_address": {
+          "name": "author_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "approval_votes_stage_id_stages_id_fk": {
+          "name": "approval_votes_stage_id_stages_id_fk",
+          "tableFrom": "approval_votes",
+          "tableTo": "stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "approval_votes_author_address_users_address_fk": {
+          "name": "approval_votes_author_address_users_address_fk",
+          "tableFrom": "approval_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_address"
+          ],
+          "columnsTo": [
+            "address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "approval_votes_stage_id_author_address_unique": {
+          "name": "approval_votes_stage_id_author_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stage_id",
+            "author_address"
+          ]
+        }
+      }
+    },
+    "public.grants": {
+      "name": "grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "grant_number": {
+          "name": "grant_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "milestones": {
+          "name": "milestones",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "showcaseVideoUrl": {
+          "name": "showcaseVideoUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestedFunds": {
+          "name": "requestedFunds",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github": {
+          "name": "github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "twitter": {
+          "name": "twitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram": {
+          "name": "telegram",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submited_at": {
+          "name": "submited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "builder_address": {
+          "name": "builder_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "grants_builder_address_users_address_fk": {
+          "name": "grants_builder_address_users_address_fk",
+          "tableFrom": "grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "builder_address"
+          ],
+          "columnsTo": [
+            "address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.large_approval_votes": {
+      "name": "large_approval_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "voted_at": {
+          "name": "voted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_address": {
+          "name": "author_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "large_approval_votes_stage_id_large_stages_id_fk": {
+          "name": "large_approval_votes_stage_id_large_stages_id_fk",
+          "tableFrom": "large_approval_votes",
+          "tableTo": "large_stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "large_approval_votes_author_address_users_address_fk": {
+          "name": "large_approval_votes_author_address_users_address_fk",
+          "tableFrom": "large_approval_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_address"
+          ],
+          "columnsTo": [
+            "address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "large_approval_votes_stage_id_author_address_unique": {
+          "name": "large_approval_votes_stage_id_author_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stage_id",
+            "author_address"
+          ]
+        }
+      }
+    },
+    "public.large_grants": {
+      "name": "large_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "showcaseVideoUrl": {
+          "name": "showcaseVideoUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "twitter": {
+          "name": "twitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram": {
+          "name": "telegram",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submited_at": {
+          "name": "submited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "builder_address": {
+          "name": "builder_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "large_grants_builder_address_users_address_fk": {
+          "name": "large_grants_builder_address_users_address_fk",
+          "tableFrom": "large_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "builder_address"
+          ],
+          "columnsTo": [
+            "address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.large_milestone_private_notes": {
+      "name": "large_milestone_private_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "written_at": {
+          "name": "written_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "milestone_id": {
+          "name": "milestone_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_address": {
+          "name": "author_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "large_milestone_private_notes_milestone_id_large_milestones_id_fk": {
+          "name": "large_milestone_private_notes_milestone_id_large_milestones_id_fk",
+          "tableFrom": "large_milestone_private_notes",
+          "tableTo": "large_milestones",
+          "columnsFrom": [
+            "milestone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "large_milestone_private_notes_author_address_users_address_fk": {
+          "name": "large_milestone_private_notes_author_address_users_address_fk",
+          "tableFrom": "large_milestone_private_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_address"
+          ],
+          "columnsTo": [
+            "address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.large_milestones": {
+      "name": "large_milestones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "milestone_number": {
+          "name": "milestone_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_deliverables": {
+          "name": "proposed_deliverables",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_completion_date": {
+          "name": "proposed_completion_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completion_proof": {
+          "name": "completion_proof",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "milestones_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'proposed'"
+        },
+        "statusNote": {
+          "name": "statusNote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_tx": {
+          "name": "verified_tx",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_by": {
+          "name": "verified_by",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_tx": {
+          "name": "payment_tx",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_by": {
+          "name": "paid_by",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "large_milestones_stage_id_large_stages_id_fk": {
+          "name": "large_milestones_stage_id_large_stages_id_fk",
+          "tableFrom": "large_milestones",
+          "tableTo": "large_stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.large_private_notes": {
+      "name": "large_private_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "written_at": {
+          "name": "written_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_address": {
+          "name": "author_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "large_private_notes_stage_id_large_stages_id_fk": {
+          "name": "large_private_notes_stage_id_large_stages_id_fk",
+          "tableFrom": "large_private_notes",
+          "tableTo": "large_stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "large_private_notes_author_address_users_address_fk": {
+          "name": "large_private_notes_author_address_users_address_fk",
+          "tableFrom": "large_private_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_address"
+          ],
+          "columnsTo": [
+            "address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.large_reject_votes": {
+      "name": "large_reject_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "voted_at": {
+          "name": "voted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_address": {
+          "name": "author_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "large_reject_votes_stage_id_large_stages_id_fk": {
+          "name": "large_reject_votes_stage_id_large_stages_id_fk",
+          "tableFrom": "large_reject_votes",
+          "tableTo": "large_stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "large_reject_votes_author_address_users_address_fk": {
+          "name": "large_reject_votes_author_address_users_address_fk",
+          "tableFrom": "large_reject_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_address"
+          ],
+          "columnsTo": [
+            "address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "large_reject_votes_stage_id_author_address_unique": {
+          "name": "large_reject_votes_stage_id_author_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stage_id",
+            "author_address"
+          ]
+        }
+      }
+    },
+    "public.large_stages": {
+      "name": "large_stages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stage_number": {
+          "name": "stage_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "submited_at": {
+          "name": "submited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "grant_id": {
+          "name": "grant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "stage_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'proposed'"
+        },
+        "statusNote": {
+          "name": "statusNote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_tx": {
+          "name": "approved_tx",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "large_stages_grant_id_large_grants_id_fk": {
+          "name": "large_stages_grant_id_large_grants_id_fk",
+          "tableFrom": "large_stages",
+          "tableTo": "large_grants",
+          "columnsFrom": [
+            "grant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.milestones": {
+      "name": "milestones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "milestone_number": {
+          "name": "milestone_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_deliverables": {
+          "name": "proposed_deliverables",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completion_proof": {
+          "name": "completion_proof",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_amount": {
+          "name": "requested_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_amount": {
+          "name": "granted_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "milestones_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'proposed'"
+        },
+        "statusNote": {
+          "name": "statusNote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_tx": {
+          "name": "payment_tx",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "milestones_stage_id_stages_id_fk": {
+          "name": "milestones_stage_id_stages_id_fk",
+          "tableFrom": "milestones",
+          "tableTo": "stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.private_notes": {
+      "name": "private_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "written_at": {
+          "name": "written_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_address": {
+          "name": "author_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "private_notes_stage_id_stages_id_fk": {
+          "name": "private_notes_stage_id_stages_id_fk",
+          "tableFrom": "private_notes",
+          "tableTo": "stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "private_notes_author_address_users_address_fk": {
+          "name": "private_notes_author_address_users_address_fk",
+          "tableFrom": "private_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_address"
+          ],
+          "columnsTo": [
+            "address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.reject_votes": {
+      "name": "reject_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "voted_at": {
+          "name": "voted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_address": {
+          "name": "author_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reject_votes_stage_id_stages_id_fk": {
+          "name": "reject_votes_stage_id_stages_id_fk",
+          "tableFrom": "reject_votes",
+          "tableTo": "stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "reject_votes_author_address_users_address_fk": {
+          "name": "reject_votes_author_address_users_address_fk",
+          "tableFrom": "reject_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_address"
+          ],
+          "columnsTo": [
+            "address"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reject_votes_stage_id_author_address_unique": {
+          "name": "reject_votes_stage_id_author_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stage_id",
+            "author_address"
+          ]
+        }
+      }
+    },
+    "public.stages": {
+      "name": "stages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stage_number": {
+          "name": "stage_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "milestone": {
+          "name": "milestone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submited_at": {
+          "name": "submited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "grant_id": {
+          "name": "grant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantAmount": {
+          "name": "grantAmount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "stage_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'proposed'"
+        },
+        "statusNote": {
+          "name": "statusNote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_tx": {
+          "name": "approved_tx",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stages_grant_id_grants_id_fk": {
+          "name": "stages_grant_id_grants_id_fk",
+          "tableFrom": "stages",
+          "tableTo": "grants",
+          "columnsFrom": [
+            "grant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'grantee'"
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_address_unique": {
+          "name": "users_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "public.milestones_status": {
+      "name": "milestones_status",
+      "schema": "public",
+      "values": [
+        "proposed",
+        "approved",
+        "completed",
+        "verified",
+        "paid",
+        "rejected"
+      ]
+    },
+    "public.stage_status": {
+      "name": "stage_status",
+      "schema": "public",
+      "values": [
+        "proposed",
+        "approved",
+        "completed",
+        "rejected"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "grantee"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/nextjs/services/database/migrations/meta/_journal.json
+++ b/packages/nextjs/services/database/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1749750852086,
       "tag": "0005_charming_wendigo",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1750356203342,
+      "tag": "0006_known_wrecker",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/nextjs/services/database/repositories/milestones.ts
+++ b/packages/nextjs/services/database/repositories/milestones.ts
@@ -1,4 +1,35 @@
-import { InferSelectModel } from "drizzle-orm";
+import { InferInsertModel, InferSelectModel, eq } from "drizzle-orm";
+import { db } from "~~/services/database/config/postgresClient";
 import { milestones } from "~~/services/database/config/schema";
 
+export type MilestoneInsert = InferInsertModel<typeof milestones>;
+export type MilestoneUpdate = Partial<MilestoneInsert>;
 export type Milestone = InferSelectModel<typeof milestones>;
+
+export async function updateMilestoneStatusToPaid({
+  milestoneId,
+  paymentTx,
+  completionProof,
+}: {
+  milestoneId: number;
+  paymentTx: string;
+  completionProof: string;
+}) {
+  return await db
+    .update(milestones)
+    .set({ status: "paid", paymentTx, completionProof, completedAt: new Date() })
+    .where(eq(milestones.id, milestoneId));
+}
+
+export async function getMilestoneByIdWithRelatedData(milestoneId: number) {
+  return await db.query.milestones.findFirst({
+    where: eq(milestones.id, milestoneId),
+    with: {
+      stage: {
+        with: {
+          grant: true,
+        },
+      },
+    },
+  });
+}

--- a/packages/nextjs/services/database/repositories/stages.ts
+++ b/packages/nextjs/services/database/repositories/stages.ts
@@ -74,3 +74,12 @@ export async function updateStageMilestonesGrantedAmounts(
     return milestoneIds;
   });
 }
+
+export async function getStageWithMilestones(stageId: number) {
+  return await db.query.stages.findFirst({
+    where: eq(stages.id, stageId),
+    with: {
+      milestones: true,
+    },
+  });
+}

--- a/packages/nextjs/services/notifications/telegram.ts
+++ b/packages/nextjs/services/notifications/telegram.ts
@@ -1,5 +1,6 @@
 import { getLargeGrantById } from "../database/repositories/large-grants";
-import { getMilestoneByIdWithRelatedData } from "../database/repositories/large-milestones";
+import { getMilestoneByIdWithRelatedData as getLargeMilestoneByIdWithRelatedData } from "../database/repositories/large-milestones";
+import { getMilestoneByIdWithRelatedData } from "../database/repositories/milestones";
 import { CreateNewGrantReqBody } from "~~/app/api/grants/new/route";
 import { CreateNewLargeGrantReqBody } from "~~/app/api/large-grants/new/route";
 import { CreateNewLargeStageReqBody } from "~~/app/api/large-stages/new/route";
@@ -10,6 +11,7 @@ const TELEGRAM_BOT_URL = process.env.TELEGRAM_BOT_URL;
 const TELEGRAM_WEBHOOK_SECRET = process.env.TELEGRAM_WEBHOOK_SECRET;
 
 export type LargeGrantDataFromDB = Awaited<ReturnType<typeof getLargeGrantById>>;
+export type LargeMilestoneDataFromDB = Awaited<ReturnType<typeof getLargeMilestoneByIdWithRelatedData>>;
 export type MilestoneDataFromDB = Awaited<ReturnType<typeof getMilestoneByIdWithRelatedData>>;
 
 type StageData = {
@@ -17,16 +19,16 @@ type StageData = {
   newLargeStage?: CreateNewLargeStageReqBody;
   grant?: GrantWithStages;
   largeGrant?: CreateNewLargeGrantReqBody | LargeGrantDataFromDB;
-  largeMilestone?: MilestoneDataFromDB;
+  largeMilestone?: LargeMilestoneDataFromDB;
+  milestone?: MilestoneDataFromDB;
 };
 
 type GrantData = CreateNewGrantReqBody & { builderAddress: string };
 type LargeGrantData = CreateNewLargeGrantReqBody & { builderAddress: string };
 
-export async function notifyTelegramBot<T extends "grant" | "stage" | "largeGrant" | "largeStage" | "largeMilestone">(
-  endpoint: T,
-  data: T extends "grant" ? GrantData : T extends "largeGrant" ? LargeGrantData : StageData,
-) {
+export async function notifyTelegramBot<
+  T extends "grant" | "stage" | "largeGrant" | "largeStage" | "largeMilestone" | "milestone",
+>(endpoint: T, data: T extends "grant" ? GrantData : T extends "largeGrant" ? LargeGrantData : StageData) {
   if (!TELEGRAM_BOT_URL || !TELEGRAM_WEBHOOK_SECRET) {
     if (!TELEGRAM_BOT_URL) {
       console.warn("TELEGRAM_BOT_URL is not set. Telegram notifications will be disabled.");


### PR DESCRIPTION
- Added a Withdraw button to each current stage milestone.
- Changed withdraw modal to show milestone info, with fixed amount (screenshot below).
- After withdraw from contract the backend is updated. No sign, because the backend is checking the address from session. Please, let me know if you think that the signing is still useful.
- After the last milestone is completed, the stage is automatically completed.
- Removed paidAt field from milestone table, because is the same that completedAt.
- I will create an issue to update Telegram bot to add a notification when a milestone is completed.

![localhost_3000_grants_112](https://github.com/user-attachments/assets/2029ef1d-60d0-41f1-9a1e-52d7a57c9680)

closes #119 