### PR TITLE
Allow to see all grant description on home page

### DIFF
--- a/packages/nextjs/app/_components/Grants/GrantDescriptionModal.tsx
+++ b/packages/nextjs/app/_components/Grants/GrantDescriptionModal.tsx
@@ -1,0 +1,30 @@
+import { forwardRef } from "react";
+import { multilineStringToTsx } from "~~/utils/multiline-string-to-tsx";
+
+type GrantDescriptionModalProps = {
+  description: string;
+  id: number;
+};
+
+export const GrantDescriptionModal = forwardRef<HTMLDialogElement, GrantDescriptionModalProps>(
+  ({ description, id }, ref) => {
+    return (
+      <dialog id={`milestones_modal_${id}`} className="modal" ref={ref}>
+        <div className="modal-box flex flex-col space-y-3">
+          <form method="dialog" className="bg-secondary -mx-6 -mt-6 px-6 py-4">
+            <div className="flex items-center">
+              <p className="font-bold text-xl m-0 text-center w-full">Grant Description</p>
+            </div>
+            {/* if there is a button in form, it will close the modal */}
+            <button className="btn btn-sm btn-circle btn-ghost text-xl h-auto absolute top-3.5 right-6">✕</button>
+          </form>
+          <div className="max-h-96 overflow-y-auto text-gray-700 whitespace-pre-line">
+            {multilineStringToTsx(description)}
+          </div>
+        </div>
+      </dialog>
+    );
+  },
+);
+
+GrantDescriptionModal.displayName = "GrantDescriptionModal";

--- a/packages/nextjs/app/_components/Grants/GrantItem.tsx
+++ b/packages/nextjs/app/_components/Grants/GrantItem.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { ExportGrantMarkdown } from "../../admin/_components/ExportGrantMarkdown";
+import { GrantDescriptionModal } from "./GrantDescriptionModal";
 import { GrantMilestonesModal } from "./GrantMilestonesModal";
 import { formatEther } from "viem";
 import { ClipboardIcon } from "@heroicons/react/24/outline";
@@ -23,11 +24,11 @@ type GrantItemProps = {
 
 export const GrantItem = ({ grant, latestsShownStatus }: GrantItemProps) => {
   const milestonesRef = useRef<HTMLDialogElement>(null);
+  const descriptionModalRef = useRef<HTMLDialogElement>(null);
   const { isAdmin } = useAuthSession();
 
   const [showMarkdown, setShowMarkdown] = useState(false);
   const [copied, setCopied] = useState(false);
-  const [showDescriptionModal, setShowDescriptionModal] = useState(false);
   const [isDescriptionTruncated, setIsDescriptionTruncated] = useState(false);
   const descriptionRef = useRef<HTMLDivElement>(null);
 
@@ -128,8 +129,8 @@ export const GrantItem = ({ grant, latestsShownStatus }: GrantItemProps) => {
         </div>
         {isDescriptionTruncated && (
           <button
-            className="text-blue-500 hover:underline text-sm mt-1 self-end"
-            onClick={() => setShowDescriptionModal(true)}
+            className="text-primary hover:underline text-sm mt-1 self-end"
+            onClick={() => descriptionModalRef && descriptionModalRef.current?.showModal()}
             type="button"
           >
             Read more
@@ -165,24 +166,7 @@ export const GrantItem = ({ grant, latestsShownStatus }: GrantItemProps) => {
           </div>
         </div>
       )}
-      {showDescriptionModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
-          <div className="bg-white p-6 rounded shadow-lg max-w-2xl w-full relative">
-            <h2 className="text-xl font-bold mb-4">Grant Description</h2>
-            <div className="max-h-96 overflow-y-auto text-gray-700 whitespace-pre-line">
-              {multilineStringToTsx(grant.description)}
-            </div>
-            <button
-              className="absolute top-2 right-2 text-gray-500 hover:text-gray-700 text-2xl font-bold"
-              onClick={() => setShowDescriptionModal(false)}
-              aria-label="Close"
-              type="button"
-            >
-              ×
-            </button>
-          </div>
-        </div>
-      )}
+      <GrantDescriptionModal ref={descriptionModalRef} description={grant.description} id={grant.id} />
     </div>
   );
 };

--- a/packages/nextjs/app/_components/Grants/GrantItem.tsx
+++ b/packages/nextjs/app/_components/Grants/GrantItem.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { ExportGrantMarkdown } from "../../admin/_components/ExportGrantMarkdown";
 import { GrantMilestonesModal } from "./GrantMilestonesModal";
@@ -27,6 +27,9 @@ export const GrantItem = ({ grant, latestsShownStatus }: GrantItemProps) => {
 
   const [showMarkdown, setShowMarkdown] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [showDescriptionModal, setShowDescriptionModal] = useState(false);
+  const [isDescriptionTruncated, setIsDescriptionTruncated] = useState(false);
+  const descriptionRef = useRef<HTMLDivElement>(null);
 
   const latestStage =
     latestsShownStatus === "approved"
@@ -68,6 +71,12 @@ export const GrantItem = ({ grant, latestsShownStatus }: GrantItemProps) => {
     }
   };
 
+  useEffect(() => {
+    if (descriptionRef.current) {
+      setIsDescriptionTruncated(descriptionRef.current.scrollHeight > descriptionRef.current.clientHeight);
+    }
+  }, [grant.description]);
+
   return (
     <div className="card flex flex-col bg-white text-primary-content w-full max-w-96 shadow-lg rounded-lg overflow-hidden">
       <div className="px-3 py-3 flex justify-between items-center w-full">
@@ -101,7 +110,7 @@ export const GrantItem = ({ grant, latestsShownStatus }: GrantItemProps) => {
             <h2 className="text-2xl font-bold">{grant.title}</h2>
           )}
         </div>
-        <Address address={grant.builderAddress} />
+        <Address address={grant.builderAddress as `0x${string}`} />
       </div>
       <div className="px-5 py-4 w-full">
         <GrantProgressBar
@@ -111,7 +120,21 @@ export const GrantItem = ({ grant, latestsShownStatus }: GrantItemProps) => {
         />
       </div>
       <div className="px-5 pb-5 flex flex-col justify-between flex-grow">
-        <div className="text-gray-400 line-clamp-4">{multilineStringToTsx(grant.description)}</div>
+        <div
+          className={`text-gray-400 ${allWithdrawals.length > 0 ? "line-clamp-4" : "line-clamp-6"}`}
+          ref={descriptionRef}
+        >
+          {multilineStringToTsx(grant.description)}
+        </div>
+        {isDescriptionTruncated && (
+          <button
+            className="text-blue-500 hover:underline text-sm mt-1 self-end"
+            onClick={() => setShowDescriptionModal(true)}
+            type="button"
+          >
+            Read more
+          </button>
+        )}
         {allWithdrawals.length > 0 && (
           <Button
             className="mt-6"
@@ -139,6 +162,24 @@ export const GrantItem = ({ grant, latestsShownStatus }: GrantItemProps) => {
                 Close
               </button>
             </div>
+          </div>
+        </div>
+      )}
+      {showDescriptionModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+          <div className="bg-white p-6 rounded shadow-lg max-w-2xl w-full relative">
+            <h2 className="text-xl font-bold mb-4">Grant Description</h2>
+            <div className="max-h-96 overflow-y-auto text-gray-700 whitespace-pre-line">
+              {multilineStringToTsx(grant.description)}
+            </div>
+            <button
+              className="absolute top-2 right-2 text-gray-500 hover:text-gray-700 text-2xl font-bold"
+              onClick={() => setShowDescriptionModal(false)}
+              aria-label="Close"
+              type="button"
+            >
+              ×
+            </button>
           </div>
         </div>
       )}

--- a/packages/nextjs/app/_components/Grants/LargeGrantItem.tsx
+++ b/packages/nextjs/app/_components/Grants/LargeGrantItem.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { ExportLargeGrantMarkdown } from "../../admin/_components/ExportLargeGrantMarkdown";
 import { LargeGrantMilestonesModal } from "./LargeGrantMilestonesModal";
@@ -25,6 +25,9 @@ export const LargeGrantItem = ({ grant, latestsShownStatus }: GrantItemProps) =>
   const { isAdmin } = useAuthSession();
   const [showMarkdown, setShowMarkdown] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [showDescriptionModal, setShowDescriptionModal] = useState(false);
+  const [isDescriptionTruncated, setIsDescriptionTruncated] = useState(false);
+  const descriptionRef = useRef<HTMLDivElement>(null);
 
   const latestStage =
     latestsShownStatus === "approved"
@@ -51,6 +54,12 @@ export const LargeGrantItem = ({ grant, latestsShownStatus }: GrantItemProps) =>
 
   // Only generate markdown if grant is an AdminLargeGrant
   const markdown = "email" in grant ? ExportLargeGrantMarkdown({ grant }) : "";
+
+  useEffect(() => {
+    if (descriptionRef.current) {
+      setIsDescriptionTruncated(descriptionRef.current.scrollHeight > descriptionRef.current.clientHeight);
+    }
+  }, [grant.description]);
 
   const handleCopy = async () => {
     try {
@@ -107,7 +116,21 @@ export const LargeGrantItem = ({ grant, latestsShownStatus }: GrantItemProps) =>
         />
       </div>
       <div className="px-5 pb-5 flex flex-col justify-between flex-grow">
-        <div className="text-gray-400 line-clamp-4">{multilineStringToTsx(grant.description)}</div>
+        <div
+          className={`text-gray-400 ${completedMilestones.length > 0 ? "line-clamp-4" : "line-clamp-6"}`}
+          ref={descriptionRef}
+        >
+          {multilineStringToTsx(grant.description)}
+        </div>
+        {isDescriptionTruncated && (
+          <button
+            className="text-blue-500 hover:underline text-sm mt-1 self-end"
+            onClick={() => setShowDescriptionModal(true)}
+            type="button"
+          >
+            Read more
+          </button>
+        )}
         {completedMilestones.length > 0 && (
           <Button
             className="mt-6"
@@ -139,6 +162,24 @@ export const LargeGrantItem = ({ grant, latestsShownStatus }: GrantItemProps) =>
                 Close
               </button>
             </div>
+          </div>
+        </div>
+      )}
+      {showDescriptionModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+          <div className="bg-white p-6 rounded shadow-lg max-w-2xl w-full relative">
+            <h2 className="text-xl font-bold mb-4">Grant Description</h2>
+            <div className="max-h-96 overflow-y-auto text-gray-700 whitespace-pre-line">
+              {multilineStringToTsx(grant.description)}
+            </div>
+            <button
+              className="absolute top-2 right-2 text-gray-500 hover:text-gray-700 text-2xl font-bold"
+              onClick={() => setShowDescriptionModal(false)}
+              aria-label="Close"
+              type="button"
+            >
+              ×
+            </button>
           </div>
         </div>
       )}

--- a/packages/nextjs/app/_components/Grants/LargeGrantItem.tsx
+++ b/packages/nextjs/app/_components/Grants/LargeGrantItem.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { ExportLargeGrantMarkdown } from "../../admin/_components/ExportLargeGrantMarkdown";
+import { GrantDescriptionModal } from "./GrantDescriptionModal";
 import { LargeGrantMilestonesModal } from "./LargeGrantMilestonesModal";
 import { ClipboardIcon } from "@heroicons/react/24/outline";
 import { Badge } from "~~/components/pg-ens/Badge";
@@ -22,10 +23,10 @@ type GrantItemProps = {
 
 export const LargeGrantItem = ({ grant, latestsShownStatus }: GrantItemProps) => {
   const milestonesRef = useRef<HTMLDialogElement>(null);
+  const descriptionModalRef = useRef<HTMLDialogElement>(null);
   const { isAdmin } = useAuthSession();
   const [showMarkdown, setShowMarkdown] = useState(false);
   const [copied, setCopied] = useState(false);
-  const [showDescriptionModal, setShowDescriptionModal] = useState(false);
   const [isDescriptionTruncated, setIsDescriptionTruncated] = useState(false);
   const descriptionRef = useRef<HTMLDivElement>(null);
 
@@ -124,8 +125,8 @@ export const LargeGrantItem = ({ grant, latestsShownStatus }: GrantItemProps) =>
         </div>
         {isDescriptionTruncated && (
           <button
-            className="text-blue-500 hover:underline text-sm mt-1 self-end"
-            onClick={() => setShowDescriptionModal(true)}
+            className="text-primary hover:underline text-sm mt-1 self-end"
+            onClick={() => descriptionModalRef && descriptionModalRef.current?.showModal()}
             type="button"
           >
             Read more
@@ -165,24 +166,7 @@ export const LargeGrantItem = ({ grant, latestsShownStatus }: GrantItemProps) =>
           </div>
         </div>
       )}
-      {showDescriptionModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
-          <div className="bg-white p-6 rounded shadow-lg max-w-2xl w-full relative">
-            <h2 className="text-xl font-bold mb-4">Grant Description</h2>
-            <div className="max-h-96 overflow-y-auto text-gray-700 whitespace-pre-line">
-              {multilineStringToTsx(grant.description)}
-            </div>
-            <button
-              className="absolute top-2 right-2 text-gray-500 hover:text-gray-700 text-2xl font-bold"
-              onClick={() => setShowDescriptionModal(false)}
-              aria-label="Close"
-              type="button"
-            >
-              ×
-            </button>
-          </div>
-        </div>
-      )}
+      <GrantDescriptionModal ref={descriptionModalRef} description={grant.description} id={grant.id} />
     </div>
   );
 };


### PR DESCRIPTION
Added a "Read more" when the text is larger than the text is displayed.

Show more text if no milestones button is shown.



<img width="1581" height="548" alt="localhost_3001_ (19)" src="https://github.com/user-attachments/assets/9672b026-b349-4d21-835f-4c35b6daad7d" />

closes #137 