### PR TITLE
Add legacy withdrawals for legacy eth grants (no milestones)

### DIFF
--- a/packages/nextjs/app/grants/[grantId]/_components/CurrentStage/WithdrawModal/LegacyWithdrawModal.tsx
+++ b/packages/nextjs/app/grants/[grantId]/_components/CurrentStage/WithdrawModal/LegacyWithdrawModal.tsx
@@ -13,7 +13,6 @@ import { useScaffoldWriteContract } from "~~/hooks/scaffold-eth";
 import { Stage } from "~~/services/database/repositories/stages";
 import { getParsedError, notification } from "~~/utils/scaffold-eth";
 
-// Props for legacy modal
 export type LegacyWithdrawModalProps = {
   stage: Stage;
   closeModal: () => void;

--- a/packages/nextjs/app/grants/[grantId]/_components/CurrentStage/WithdrawModal/LegacyWithdrawModal.tsx
+++ b/packages/nextjs/app/grants/[grantId]/_components/CurrentStage/WithdrawModal/LegacyWithdrawModal.tsx
@@ -1,0 +1,99 @@
+import { forwardRef } from "react";
+import { useRouter } from "next/navigation";
+import { LegacyWithdrawModalFormValues, legacyWithdrawModalFormSchema } from "./schema";
+import { FormProvider } from "react-hook-form";
+import { Toaster } from "react-hot-toast";
+import { parseEther } from "viem";
+import { apolloClient } from "~~/components/ScaffoldEthAppWithProviders";
+import { Button } from "~~/components/pg-ens/Button";
+import { FormInput } from "~~/components/pg-ens/form-fields/FormInput";
+import { FormTextarea } from "~~/components/pg-ens/form-fields/FormTextarea";
+import { useFormMethods } from "~~/hooks/pg-ens/useFormMethods";
+import { useScaffoldWriteContract } from "~~/hooks/scaffold-eth";
+import { Stage } from "~~/services/database/repositories/stages";
+import { getParsedError, notification } from "~~/utils/scaffold-eth";
+
+// Props for legacy modal
+export type LegacyWithdrawModalProps = {
+  stage: Stage;
+  closeModal: () => void;
+  contractGrantId?: bigint;
+  refetchContractInfo: () => Promise<any>;
+};
+
+export const LegacyWithdrawModal = forwardRef<HTMLDialogElement, LegacyWithdrawModalProps>(
+  ({ closeModal, contractGrantId, refetchContractInfo }, ref) => {
+    const router = useRouter();
+
+    const { formMethods, getCommonOptions } = useFormMethods<LegacyWithdrawModalFormValues>({
+      schema: legacyWithdrawModalFormSchema,
+    });
+    const { handleSubmit, reset: clearFormValues } = formMethods;
+
+    const { writeContractAsync, isPending: isWritingWithOnChain } = useScaffoldWriteContract("Stream");
+
+    const onSubmit = async (fieldValues: LegacyWithdrawModalFormValues) => {
+      let txnHash: string | undefined;
+      try {
+        const { completedMilestones, withdrawAmount } = fieldValues;
+
+        txnHash = await writeContractAsync({
+          functionName: "streamWithdraw",
+          args: [contractGrantId, parseEther(withdrawAmount), completedMilestones],
+        });
+
+        await apolloClient.refetchQueries({
+          include: "active",
+        });
+        await refetchContractInfo();
+
+        closeModal();
+        clearFormValues();
+        router.refresh();
+      } catch (error) {
+        if (!txnHash) {
+          // error was from writeContractAsync and already handled
+          return;
+        }
+        const errorMessage = getParsedError(error);
+        notification.error(errorMessage);
+      }
+    };
+
+    return (
+      <dialog id="action_modal" className="modal" ref={ref}>
+        <div className="modal-box flex flex-col space-y-3">
+          <form method="dialog" className="bg-secondary -mx-6 -mt-6 px-6 py-4 flex items-center justify-between">
+            <div className="flex justify-between items-center">
+              <p className="font-bold text-xl m-0">Withdraw a milestone</p>
+            </div>
+            {/* if there is a button in form, it will close the modal */}
+            <button className="btn btn-sm btn-circle btn-ghost text-xl h-auto">✕</button>
+          </form>
+          <FormProvider {...formMethods}>
+            <form onSubmit={handleSubmit(onSubmit)} className="w-full flex flex-col space-y-1">
+              <FormInput label="Amount (in ETH)" {...getCommonOptions("withdrawAmount")} />
+              <div className="flex flex-col">
+                <FormTextarea
+                  label="Completed Milestone and proof of completion"
+                  showMessageLength
+                  {...getCommonOptions("completedMilestones")}
+                />
+                <span className="text-sm italic text-right pb-4">
+                  *Video walkthrough, GitHub repo or other deliverables
+                </span>
+              </div>
+              <Button type="submit" disabled={isWritingWithOnChain} className="self-center">
+                {isWritingWithOnChain && <span className="loading loading-spinner"></span>}
+                Withdraw
+              </Button>
+            </form>
+          </FormProvider>
+        </div>
+        <Toaster />
+      </dialog>
+    );
+  },
+);
+
+LegacyWithdrawModal.displayName = "LegacyWithdrawModal";

--- a/packages/nextjs/app/grants/[grantId]/_components/CurrentStage/WithdrawModal/index.tsx
+++ b/packages/nextjs/app/grants/[grantId]/_components/CurrentStage/WithdrawModal/index.tsx
@@ -106,15 +106,15 @@ export const WithdrawModal = forwardRef<HTMLDialogElement, WithdrawModalProps>(
             <form onSubmit={handleSubmit(onSubmit)} className="w-full flex flex-col space-y-1 mt-4">
               <div className="text-xl">
                 <span className="font-bold">Description:</span>
-                <p className="mt-1">{multilineStringToTsx(milestone.description)}</p>
+                <div className="mt-1">{multilineStringToTsx(milestone.description)}</div>
               </div>
               <div className="text-xl">
                 <span className="font-bold">Amount:</span>
-                <p className="mt-1">{formatEther(milestone.grantedAmount || 0n)} ETH</p>
+                <div className="mt-1">{formatEther(milestone.grantedAmount || 0n)} ETH</div>
               </div>
               <div>
                 <span className="text-xl font-bold">Detail of Deliverables:</span>
-                <p className="text-lg mt-1">{multilineStringToTsx(milestone.proposedDeliverables)}</p>
+                <div className="text-lg mt-1">{multilineStringToTsx(milestone.proposedDeliverables)}</div>
               </div>
               <div className="flex flex-col">
                 <FormTextarea label="Proof of completion" showMessageLength {...getCommonOptions("completionProof")} />

--- a/packages/nextjs/app/grants/[grantId]/_components/CurrentStage/WithdrawModal/schema.tsx
+++ b/packages/nextjs/app/grants/[grantId]/_components/CurrentStage/WithdrawModal/schema.tsx
@@ -6,3 +6,14 @@ export const withdrawModalFormSchema = z.object({
 });
 
 export type WithdrawModalFormValues = z.infer<typeof withdrawModalFormSchema>;
+
+// Legacy schema for legacy WithdrawModal
+export const legacyWithdrawModalFormSchema = z.object({
+  withdrawAmount: z.string().min(1, { message: "Amount is required" }),
+  completedMilestones: z
+    .string()
+    .min(20, { message: "At least 20 characters required" })
+    .max(DEFAULT_TEXTAREA_MAX_LENGTH),
+});
+
+export type LegacyWithdrawModalFormValues = z.infer<typeof legacyWithdrawModalFormSchema>;

--- a/packages/nextjs/app/grants/[grantId]/_components/CurrentStage/WithdrawModal/schema.tsx
+++ b/packages/nextjs/app/grants/[grantId]/_components/CurrentStage/WithdrawModal/schema.tsx
@@ -7,7 +7,6 @@ export const withdrawModalFormSchema = z.object({
 
 export type WithdrawModalFormValues = z.infer<typeof withdrawModalFormSchema>;
 
-// Legacy schema for legacy WithdrawModal
 export const legacyWithdrawModalFormSchema = z.object({
   withdrawAmount: z.string().min(1, { message: "Amount is required" }),
   completedMilestones: z

--- a/packages/nextjs/app/grants/[grantId]/_components/CurrentStage/index.tsx
+++ b/packages/nextjs/app/grants/[grantId]/_components/CurrentStage/index.tsx
@@ -77,7 +77,6 @@ export const CurrentStage = ({ grant }: CurrentStageProps) => {
         </div>
       )}
 
-      {/* Render milestones if present */}
       {latestStage.milestones.length > 0 &&
         latestStage.milestones.map(milestone => (
           <MilestoneDetail
@@ -97,7 +96,6 @@ export const CurrentStage = ({ grant }: CurrentStageProps) => {
         closeModal={() => newStageModalRef.current?.close()}
       />
 
-      {/* Legacy WithdrawModal for stages with no milestones */}
       {latestStage.milestones.length === 0 && (
         <LegacyWithdrawModal
           ref={withdrawModalRef}


### PR DESCRIPTION
After implementing the new milestone system for ETH grants, realized that legacy ETH grants have no way to withdraw their active grants through the UI (they would need to withdraw from the contract directly).

Tried to implement the old withdraw system to the grants with no milestones attached. Once their grants are completed, they'll be able to apply to a new stage (with milestones in this case).

To test properly I created a ETH grant with [main] branch code and database, and with the active chain+stream contract then updated database schema and code to this branch. This way you can withdraw from the old and new system, like the real scenario when we update the system.

cc @damianmarti so he can take a look and tweak if I missed something when he's back