### PR TITLE
Check valid session before on-chain transactions

### DIFF
--- a/packages/nextjs/app/admin/_components/FinalApproveModal/index.tsx
+++ b/packages/nextjs/app/admin/_components/FinalApproveModal/index.tsx
@@ -9,9 +9,12 @@ import { FormSelect } from "~~/components/pg-ens/form-fields/FormSelect";
 import { FormTextarea } from "~~/components/pg-ens/form-fields/FormTextarea";
 import { Address } from "~~/components/scaffold-eth";
 import { useFormMethods } from "~~/hooks/pg-ens/useFormMethods";
+import { useHandleLogin } from "~~/hooks/pg-ens/useHandleLogin";
 import { useStageReview } from "~~/hooks/pg-ens/useStageReview";
 import { useScaffoldReadContract, useScaffoldWriteContract } from "~~/hooks/scaffold-eth";
+import { hasActiveAdminSession } from "~~/utils/admin-session";
 import { notification } from "~~/utils/scaffold-eth";
+import { REAUTH_UI_TEXT, SESSION_MESSAGES } from "~~/utils/session-messages";
 
 const LOADING_STATUS_MAP = {
   CreatingStream: "Creating grant stream",
@@ -48,6 +51,10 @@ export const FinalApproveModal = forwardRef<
 >(({ stage, grantName, builderAddress, isGrant, grantNumber }, ref) => {
   const { reviewStage, isSigning } = useStageReview(stage.id);
   const [loadingStatus, setLoadingStatus] = useState<LoadingStatus>(LOADING_STATUS_MAP.Empty);
+  const [pendingApprovedTxHash, setPendingApprovedTxHash] = useState<string | null>(null);
+  const [requiresAdminSession, setRequiresAdminSession] = useState(false);
+  const [isReauthenticating, setIsReauthenticating] = useState(false);
+  const { handleLogin } = useHandleLogin();
   const { approvalVotes } = stage;
 
   const { formMethods, getCommonOptions } = useFormMethods<FinalApproveModalFormValues>({
@@ -60,7 +67,7 @@ export const FinalApproveModal = forwardRef<
     },
   });
 
-  const { handleSubmit, control, watch } = formMethods;
+  const { handleSubmit, control, watch, getValues } = formMethods;
 
   const { writeContractAsync, isPending: isWriteContractPending } = useScaffoldWriteContract("Stream");
 
@@ -81,6 +88,12 @@ export const FinalApproveModal = forwardRef<
 
   const watchMilestones = watch("milestones");
   const totalAmount = watchMilestones.reduce((acc, curr) => acc + Number(curr.grantedAmount), 0);
+
+  const closeDialog = () => {
+    if (ref && typeof ref !== "function") {
+      ref.current?.close();
+    }
+  };
 
   const handleSetupStream = async () => {
     try {
@@ -113,20 +126,83 @@ export const FinalApproveModal = forwardRef<
   };
 
   const onSubmit = async (fieldValues: FinalApproveModalFormValues) => {
-    const txHash = await handleSetupStream();
+    const hasAdminSession = await hasActiveAdminSession();
+    if (!hasAdminSession) {
+      setLoadingStatus(LOADING_STATUS_MAP.Empty);
+      setRequiresAdminSession(true);
+      notification.error(SESSION_MESSAGES.adminExpiredFinalApproval);
+      return;
+    }
+    setRequiresAdminSession(false);
+
+    const txHash = pendingApprovedTxHash || (await handleSetupStream());
     if (!txHash) {
       setLoadingStatus(LOADING_STATUS_MAP.Empty);
       return notification.error("Error setting up stream");
     }
+
+    setPendingApprovedTxHash(txHash);
     setLoadingStatus(LOADING_STATUS_MAP.Approving);
-    await reviewStage({
+    const isReviewed = await reviewStage({
       status: "approved",
       ...fieldValues,
       txHash,
       grantNumber: grantNumber.toString(),
       grantAmount: totalAmount.toString(),
     });
+
+    if (isReviewed) {
+      setPendingApprovedTxHash(null);
+      setRequiresAdminSession(false);
+    }
+
     setLoadingStatus(LOADING_STATUS_MAP.Empty);
+  };
+
+  const handleReauthenticateAndRetry = async () => {
+    if (isReauthenticating) return;
+
+    setIsReauthenticating(true);
+    try {
+      const loggedIn = await handleLogin();
+      if (!loggedIn) {
+        notification.error(SESSION_MESSAGES.reauthFailed);
+        return;
+      }
+
+      const hasAdminSession = await hasActiveAdminSession();
+      if (!hasAdminSession) {
+        setRequiresAdminSession(true);
+        notification.error(SESSION_MESSAGES.adminPermissionsRequired);
+        return;
+      }
+
+      setRequiresAdminSession(false);
+
+      if (!pendingApprovedTxHash) {
+        notification.success(SESSION_MESSAGES.sessionRestoredSubmitAgain);
+        return;
+      }
+
+      setLoadingStatus(LOADING_STATUS_MAP.Approving);
+      const fieldValues = getValues();
+      const isReviewed = await reviewStage({
+        status: "approved",
+        ...fieldValues,
+        txHash: pendingApprovedTxHash,
+        grantNumber: grantNumber.toString(),
+        grantAmount: totalAmount.toString(),
+      });
+
+      if (isReviewed) {
+        setPendingApprovedTxHash(null);
+        setRequiresAdminSession(false);
+        closeDialog();
+      }
+    } finally {
+      setLoadingStatus(LOADING_STATUS_MAP.Empty);
+      setIsReauthenticating(false);
+    }
   };
 
   const loadingStatusText = getLoadingStatusText({
@@ -152,7 +228,7 @@ export const FinalApproveModal = forwardRef<
 
               {approvalVotes.map(approvalVote => (
                 <div key={approvalVote.id} className="flex items-center gap-2">
-                  <Address address={approvalVote.authorAddress} />
+                  <Address address={approvalVote.authorAddress as `0x${string}`} />
                   {approvalVote.amount && <span>({formatEther(approvalVote.amount)} ETH suggested)</span>}
                 </div>
               ))}
@@ -188,13 +264,43 @@ export const FinalApproveModal = forwardRef<
             <h3 className="text-xl font-bold">Total Granted: {totalAmount} ETH</h3>
             <hr className="border-t border-black my-2" />
             <FormTextarea label="Note (visible to grantee)" {...getCommonOptions("statusNote")} />
+            {(pendingApprovedTxHash || requiresAdminSession) && !loadingStatus && (
+              <div className="rounded-lg border border-warning px-3 py-2 my-2">
+                <p className="text-sm mb-2">
+                  {pendingApprovedTxHash
+                    ? REAUTH_UI_TEXT.finalApprovalPendingSync
+                    : REAUTH_UI_TEXT.finalApprovalSessionExpired}
+                </p>
+                <Button
+                  variant="secondary"
+                  type="button"
+                  size="sm"
+                  className="!px-4"
+                  onClick={handleReauthenticateAndRetry}
+                  disabled={isReauthenticating}
+                >
+                  <span>
+                    {isReauthenticating
+                      ? REAUTH_UI_TEXT.reauthenticating
+                      : pendingApprovedTxHash
+                      ? REAUTH_UI_TEXT.reauthAndRetry
+                      : REAUTH_UI_TEXT.reauth}
+                  </span>
+                </Button>
+              </div>
+            )}
             {loadingStatusText && (
               <div className="text-xl flex justify-center items-center gap-2 my-2">
                 <span className="loading loading-spinner" />
                 {loadingStatusText}
               </div>
             )}
-            <Button variant="green" type="submit" className="!px-4 self-center" disabled={Boolean(loadingStatus)}>
+            <Button
+              variant="green"
+              type="submit"
+              className="!px-4 self-center"
+              disabled={Boolean(loadingStatus) || isReauthenticating}
+            >
               <span>Final Approve</span>
             </Button>
           </form>

--- a/packages/nextjs/app/admin/_components/LargeGrantFinalApproveModal/index.tsx
+++ b/packages/nextjs/app/admin/_components/LargeGrantFinalApproveModal/index.tsx
@@ -7,10 +7,13 @@ import { Button } from "~~/components/pg-ens/Button";
 import { FormTextarea } from "~~/components/pg-ens/form-fields/FormTextarea";
 import { Address } from "~~/components/scaffold-eth";
 import { useFormMethods } from "~~/hooks/pg-ens/useFormMethods";
+import { useHandleLogin } from "~~/hooks/pg-ens/useHandleLogin";
 import { useLargeStageReview } from "~~/hooks/pg-ens/useLargeStageReview";
 import { useScaffoldReadContract, useScaffoldWriteContract } from "~~/hooks/scaffold-eth";
 import { LargeGrantWithStagesAndPrivateNotes } from "~~/types/utils";
+import { hasActiveAdminSession } from "~~/utils/admin-session";
 import { notification } from "~~/utils/scaffold-eth";
+import { REAUTH_UI_TEXT, SESSION_MESSAGES } from "~~/utils/session-messages";
 
 const LOADING_STATUS_MAP = {
   CreatingGrant: "Creating grant in contract",
@@ -47,13 +50,17 @@ export const LargeGrantFinalApproveModal = forwardRef<
 >(({ stage, grantName, builderAddress, isGrant, grantId }, ref) => {
   const { reviewStage, isSigning } = useLargeStageReview(stage.id);
   const [loadingStatus, setLoadingStatus] = useState<LoadingStatus>(LOADING_STATUS_MAP.Empty);
+  const [pendingApprovedTxHash, setPendingApprovedTxHash] = useState<string | null>(null);
+  const [requiresAdminSession, setRequiresAdminSession] = useState(false);
+  const [isReauthenticating, setIsReauthenticating] = useState(false);
+  const { handleLogin } = useHandleLogin();
   const { approvalVotes } = stage;
 
   const { getCommonOptions, formMethods } = useFormMethods<FinalApproveModalFormValues>({
     schema: finalApproveModalFormSchema,
   });
 
-  const { handleSubmit } = formMethods;
+  const { handleSubmit, getValues } = formMethods;
 
   const { writeContractAsync, isPending: isWriteContractPending } = useScaffoldWriteContract("LargeGrant");
 
@@ -65,6 +72,12 @@ export const LargeGrantFinalApproveModal = forwardRef<
       enabled: !isGrant,
     },
   });
+
+  const closeDialog = () => {
+    if (ref && typeof ref !== "function") {
+      ref.current?.close();
+    }
+  };
 
   const handleCreateGrant = async () => {
     try {
@@ -99,14 +112,71 @@ export const LargeGrantFinalApproveModal = forwardRef<
   };
 
   const onSubmit = async (fieldValues: FinalApproveModalFormValues) => {
-    const txHash = await handleCreateGrant();
+    const hasAdminSession = await hasActiveAdminSession();
+    if (!hasAdminSession) {
+      setLoadingStatus(LOADING_STATUS_MAP.Empty);
+      setRequiresAdminSession(true);
+      notification.error(SESSION_MESSAGES.adminExpiredFinalApproval);
+      return;
+    }
+    setRequiresAdminSession(false);
+
+    const txHash = pendingApprovedTxHash || (await handleCreateGrant());
     if (!txHash) {
       setLoadingStatus(LOADING_STATUS_MAP.Empty);
       return notification.error("Error setting up stream");
     }
+
+    setPendingApprovedTxHash(txHash);
     setLoadingStatus(LOADING_STATUS_MAP.Approving);
-    await reviewStage({ status: "approved", ...fieldValues, txHash });
+    const isReviewed = await reviewStage({ status: "approved", ...fieldValues, txHash });
+
+    if (isReviewed) {
+      setPendingApprovedTxHash(null);
+      setRequiresAdminSession(false);
+    }
+
     setLoadingStatus(LOADING_STATUS_MAP.Empty);
+  };
+
+  const handleReauthenticateAndRetry = async () => {
+    if (isReauthenticating) return;
+
+    setIsReauthenticating(true);
+    try {
+      const loggedIn = await handleLogin();
+      if (!loggedIn) {
+        notification.error(SESSION_MESSAGES.reauthFailed);
+        return;
+      }
+
+      const hasAdminSession = await hasActiveAdminSession();
+      if (!hasAdminSession) {
+        setRequiresAdminSession(true);
+        notification.error(SESSION_MESSAGES.adminPermissionsRequired);
+        return;
+      }
+
+      setRequiresAdminSession(false);
+
+      if (!pendingApprovedTxHash) {
+        notification.success(SESSION_MESSAGES.sessionRestoredSubmitAgain);
+        return;
+      }
+
+      setLoadingStatus(LOADING_STATUS_MAP.Approving);
+      const fieldValues = getValues();
+      const isReviewed = await reviewStage({ status: "approved", ...fieldValues, txHash: pendingApprovedTxHash });
+
+      if (isReviewed) {
+        setPendingApprovedTxHash(null);
+        setRequiresAdminSession(false);
+        closeDialog();
+      }
+    } finally {
+      setLoadingStatus(LOADING_STATUS_MAP.Empty);
+      setIsReauthenticating(false);
+    }
   };
 
   const loadingStatusText = getLoadingStatusText({
@@ -140,6 +210,31 @@ export const LargeGrantFinalApproveModal = forwardRef<
           )}
           <form onSubmit={handleSubmit(onSubmit)} className="w-full flex flex-col gap-1">
             <FormTextarea label="Note (visible to grantee)" {...getCommonOptions("statusNote")} />
+            {(pendingApprovedTxHash || requiresAdminSession) && !loadingStatus && (
+              <div className="rounded-lg border border-warning px-3 py-2 my-2">
+                <p className="text-sm mb-2">
+                  {pendingApprovedTxHash
+                    ? REAUTH_UI_TEXT.finalApprovalPendingSync
+                    : REAUTH_UI_TEXT.finalApprovalSessionExpired}
+                </p>
+                <Button
+                  variant="secondary"
+                  type="button"
+                  size="sm"
+                  className="!px-4"
+                  onClick={handleReauthenticateAndRetry}
+                  disabled={isReauthenticating}
+                >
+                  <span>
+                    {isReauthenticating
+                      ? REAUTH_UI_TEXT.reauthenticating
+                      : pendingApprovedTxHash
+                      ? REAUTH_UI_TEXT.reauthAndRetry
+                      : REAUTH_UI_TEXT.reauth}
+                  </span>
+                </Button>
+              </div>
+            )}
             {loadingStatusText && (
               <div className="text-xl flex justify-center items-center gap-2 my-2">
                 <span className="loading loading-spinner" />
@@ -151,7 +246,7 @@ export const LargeGrantFinalApproveModal = forwardRef<
               type="submit"
               size="sm"
               className="!px-4 self-center"
-              disabled={Boolean(loadingStatus)}
+              disabled={Boolean(loadingStatus) || isReauthenticating}
             >
               <span>Final Approve</span>
             </Button>

--- a/packages/nextjs/app/admin/_components/LargeMilestoneApprovalModal/index.tsx
+++ b/packages/nextjs/app/admin/_components/LargeMilestoneApprovalModal/index.tsx
@@ -8,9 +8,12 @@ import { Button } from "~~/components/pg-ens/Button";
 import { FormTextarea } from "~~/components/pg-ens/form-fields/FormTextarea";
 import { Address } from "~~/components/scaffold-eth";
 import { useFormMethods } from "~~/hooks/pg-ens/useFormMethods";
+import { useHandleLogin } from "~~/hooks/pg-ens/useHandleLogin";
 import { useLargeMilestoneReview } from "~~/hooks/pg-ens/useLargeMilestoneReview";
 import { useScaffoldWriteContract } from "~~/hooks/scaffold-eth";
+import { hasActiveAdminSession } from "~~/utils/admin-session";
 import { notification } from "~~/utils/scaffold-eth";
+import { REAUTH_UI_TEXT, SESSION_MESSAGES } from "~~/utils/session-messages";
 
 const LOADING_STATUS_MAP = {
   Approving: "Approving milestone",
@@ -43,13 +46,18 @@ export const LargeMilestoneApprovalModal = forwardRef<
 >(({ milestone, closeModal }, ref) => {
   const { reviewMilestone, isSigning } = useLargeMilestoneReview(milestone.id);
   const [loadingStatus, setLoadingStatus] = useState<LoadingStatus>(LOADING_STATUS_MAP.Empty);
+  const [pendingMilestoneTxHash, setPendingMilestoneTxHash] = useState<string | null>(null);
+  const [pendingMilestoneStatus, setPendingMilestoneStatus] = useState<"paid" | "verified" | null>(null);
+  const [requiresAdminSession, setRequiresAdminSession] = useState(false);
+  const [isReauthenticating, setIsReauthenticating] = useState(false);
+  const { handleLogin } = useHandleLogin();
   const router = useRouter();
 
   const { getCommonOptions, formMethods } = useFormMethods<FinalApproveModalFormValues>({
     schema: finalApproveModalFormSchema,
   });
 
-  const { handleSubmit } = formMethods;
+  const { handleSubmit, getValues } = formMethods;
 
   const { writeContractAsync, isPending: isWriteContractPending } = useScaffoldWriteContract("LargeGrant");
 
@@ -84,23 +92,84 @@ export const LargeMilestoneApprovalModal = forwardRef<
   };
 
   const onSubmit = async (fieldValues: FinalApproveModalFormValues) => {
-    const txHash = await handleApproveMilestone();
+    const hasAdminSession = await hasActiveAdminSession();
+    if (!hasAdminSession) {
+      setLoadingStatus(LOADING_STATUS_MAP.Empty);
+      setRequiresAdminSession(true);
+      notification.error(SESSION_MESSAGES.adminExpiredMilestoneApproval);
+      return;
+    }
+
+    setRequiresAdminSession(false);
+    const nextStatus = pendingMilestoneStatus || (milestone.status === "verified" ? "paid" : "verified");
+    const txHash = pendingMilestoneTxHash || (await handleApproveMilestone());
+
     if (!txHash) {
       setLoadingStatus(LOADING_STATUS_MAP.Empty);
       return notification.error("Error approving milestone");
     }
-    if (milestone.status === "verified") {
-      setLoadingStatus(LOADING_STATUS_MAP.Completing);
-      await reviewMilestone({ status: "paid", ...fieldValues, txHash });
-      setLoadingStatus(LOADING_STATUS_MAP.Empty);
-    }
-    if (milestone.status === "completed") {
-      setLoadingStatus(LOADING_STATUS_MAP.Approving);
-      await reviewMilestone({ status: "verified", ...fieldValues, txHash });
-      setLoadingStatus(LOADING_STATUS_MAP.Empty);
-    }
+
+    setPendingMilestoneTxHash(txHash);
+    setPendingMilestoneStatus(nextStatus);
+    setLoadingStatus(nextStatus === "paid" ? LOADING_STATUS_MAP.Completing : LOADING_STATUS_MAP.Approving);
+    const isReviewed = await reviewMilestone({ status: nextStatus, ...fieldValues, txHash });
+    setLoadingStatus(LOADING_STATUS_MAP.Empty);
+
+    if (!isReviewed) return;
+
+    setPendingMilestoneTxHash(null);
+    setPendingMilestoneStatus(null);
+    setRequiresAdminSession(false);
     closeModal();
     router.refresh();
+  };
+
+  const handleReauthenticateAndRetry = async () => {
+    if (isReauthenticating) return;
+
+    setIsReauthenticating(true);
+    try {
+      const loggedIn = await handleLogin();
+      if (!loggedIn) {
+        notification.error(SESSION_MESSAGES.reauthFailed);
+        return;
+      }
+
+      const hasAdminSession = await hasActiveAdminSession();
+      if (!hasAdminSession) {
+        setRequiresAdminSession(true);
+        notification.error(SESSION_MESSAGES.adminPermissionsRequired);
+        return;
+      }
+
+      setRequiresAdminSession(false);
+
+      if (!pendingMilestoneTxHash || !pendingMilestoneStatus) {
+        notification.success(SESSION_MESSAGES.sessionRestoredSubmitAgain);
+        return;
+      }
+
+      setLoadingStatus(
+        pendingMilestoneStatus === "paid" ? LOADING_STATUS_MAP.Completing : LOADING_STATUS_MAP.Approving,
+      );
+      const fieldValues = getValues();
+      const isReviewed = await reviewMilestone({
+        status: pendingMilestoneStatus,
+        ...fieldValues,
+        txHash: pendingMilestoneTxHash,
+      });
+
+      if (!isReviewed) return;
+
+      setPendingMilestoneTxHash(null);
+      setPendingMilestoneStatus(null);
+      setRequiresAdminSession(false);
+      closeModal();
+      router.refresh();
+    } finally {
+      setLoadingStatus(LOADING_STATUS_MAP.Empty);
+      setIsReauthenticating(false);
+    }
   };
 
   const loadingStatusText = getLoadingStatusText({
@@ -151,6 +220,31 @@ export const LargeMilestoneApprovalModal = forwardRef<
             ) : (
               <div>Are you sure you want to vote for the approval of this milestone?</div>
             )}
+            {(pendingMilestoneTxHash || requiresAdminSession) && !loadingStatus && (
+              <div className="rounded-lg border border-warning px-3 py-2 my-2">
+                <p className="text-sm mb-2">
+                  {pendingMilestoneTxHash
+                    ? REAUTH_UI_TEXT.milestonePendingSync
+                    : REAUTH_UI_TEXT.milestoneSessionExpired}
+                </p>
+                <Button
+                  variant="secondary"
+                  type="button"
+                  size="sm"
+                  className="!px-4"
+                  onClick={handleReauthenticateAndRetry}
+                  disabled={isReauthenticating}
+                >
+                  <span>
+                    {isReauthenticating
+                      ? REAUTH_UI_TEXT.reauthenticating
+                      : pendingMilestoneTxHash
+                      ? REAUTH_UI_TEXT.reauthAndRetry
+                      : REAUTH_UI_TEXT.reauth}
+                  </span>
+                </Button>
+              </div>
+            )}
             {loadingStatusText && (
               <div className="text-xl flex justify-center items-center gap-2 my-2">
                 <span className="loading loading-spinner" />
@@ -162,7 +256,7 @@ export const LargeMilestoneApprovalModal = forwardRef<
                 variant="secondary"
                 size="sm"
                 type="button"
-                disabled={Boolean(loadingStatus)}
+                disabled={Boolean(loadingStatus) || isReauthenticating}
                 className="self-center"
                 onClick={closeModal}
               >
@@ -173,7 +267,7 @@ export const LargeMilestoneApprovalModal = forwardRef<
                 type="submit"
                 className="!px-4 self-center"
                 size="sm"
-                disabled={Boolean(loadingStatus)}
+                disabled={Boolean(loadingStatus) || isReauthenticating}
               >
                 <span>{milestone.status === "verified" ? "Final Approve" : "Approve"}</span>
               </Button>

--- a/packages/nextjs/app/admin/_components/LargeMilestoneRejectModal/index.tsx
+++ b/packages/nextjs/app/admin/_components/LargeMilestoneRejectModal/index.tsx
@@ -19,7 +19,8 @@ export const LargeMilestoneRejectModal = forwardRef<HTMLDialogElement, RejectMod
   const { handleSubmit } = formMethods;
 
   const onSubmit = async (fieldValues: RejectModalFormValues) => {
-    await reviewMilestone({ status: "rejected", ...fieldValues });
+    const isReviewed = await reviewMilestone({ status: "rejected", ...fieldValues });
+    if (!isReviewed) return;
   };
 
   return (

--- a/packages/nextjs/app/grants/[grantId]/_components/CurrentStage/WithdrawModal/index.tsx
+++ b/packages/nextjs/app/grants/[grantId]/_components/CurrentStage/WithdrawModal/index.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from "react";
+import { forwardRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { WithdrawModalFormValues, withdrawModalFormSchema } from "./schema";
 import { useMutation, useQuery } from "@tanstack/react-query";
@@ -9,12 +9,15 @@ import { apolloClient } from "~~/components/ScaffoldEthAppWithProviders";
 import { Button } from "~~/components/pg-ens/Button";
 import { FormTextarea } from "~~/components/pg-ens/form-fields/FormTextarea";
 import { useFormMethods } from "~~/hooks/pg-ens/useFormMethods";
+import { useHandleLogin } from "~~/hooks/pg-ens/useHandleLogin";
 import { useScaffoldWriteContract } from "~~/hooks/scaffold-eth";
 import { Milestone } from "~~/services/database/repositories/milestones";
+import { hasActiveUserSession } from "~~/utils/admin-session";
 import { multilineStringToTsx } from "~~/utils/multiline-string-to-tsx";
 import { postMutationFetcher } from "~~/utils/react-query";
 import { fetcher } from "~~/utils/react-query";
 import { getParsedError, notification } from "~~/utils/scaffold-eth";
+import { REAUTH_UI_TEXT, SESSION_MESSAGES } from "~~/utils/session-messages";
 
 type WithdrawModalProps = {
   milestone: Milestone;
@@ -26,11 +29,16 @@ type WithdrawModalProps = {
 export const WithdrawModal = forwardRef<HTMLDialogElement, WithdrawModalProps>(
   ({ milestone, closeModal, contractGrantId, refetchContractInfo }, ref) => {
     const router = useRouter();
+    const [pendingPaymentTx, setPendingPaymentTx] = useState<string | null>(null);
+    const [pendingCompletionProof, setPendingCompletionProof] = useState<string | null>(null);
+    const [requiresSession, setRequiresSession] = useState(false);
+    const [isReauthenticating, setIsReauthenticating] = useState(false);
+    const { handleLogin } = useHandleLogin();
 
     const { formMethods, getCommonOptions } = useFormMethods<WithdrawModalFormValues>({
       schema: withdrawModalFormSchema,
     });
-    const { handleSubmit, reset: clearFormValues } = formMethods;
+    const { handleSubmit, reset: clearFormValues, getValues } = formMethods;
 
     const { writeContractAsync, isPending: isWritingWithOnChain } = useScaffoldWriteContract("Stream");
 
@@ -49,6 +57,15 @@ export const WithdrawModal = forwardRef<HTMLDialogElement, WithdrawModalProps>(
       try {
         const { completionProof } = fieldValues;
 
+        const hasUserSession = await hasActiveUserSession();
+        if (!hasUserSession) {
+          setRequiresSession(true);
+          notification.error(SESSION_MESSAGES.genericExpiredRetry);
+          return;
+        }
+
+        setRequiresSession(false);
+
         if (!milestoneStatus) {
           notification.error("Error loading milestone.");
           return;
@@ -64,15 +81,31 @@ export const WithdrawModal = forwardRef<HTMLDialogElement, WithdrawModalProps>(
           return;
         }
 
-        txnHash = await writeContractAsync({
-          functionName: "streamWithdraw",
-          args: [contractGrantId, milestone.grantedAmount || 0n, completionProof],
-        });
+        txnHash = pendingPaymentTx ?? undefined;
+
+        if (!txnHash) {
+          txnHash = await writeContractAsync({
+            functionName: "streamWithdraw",
+            args: [contractGrantId, milestone.grantedAmount || 0n, completionProof],
+          });
+        }
+
+        if (!txnHash) {
+          notification.error("Error withdrawing milestone");
+          return;
+        }
+
+        setPendingPaymentTx(txnHash);
+        setPendingCompletionProof(completionProof);
 
         await postCompleteMilestone({
-          paymentTx: txnHash || "",
+          paymentTx: txnHash,
           completionProof,
         });
+
+        setPendingPaymentTx(null);
+        setPendingCompletionProof(null);
+        setRequiresSession(false);
 
         await apolloClient.refetchQueries({
           include: "active",
@@ -87,8 +120,71 @@ export const WithdrawModal = forwardRef<HTMLDialogElement, WithdrawModalProps>(
           // error was from writeContractAsync and already handled
           return;
         }
+
+        if ((error as { status?: number })?.status === 401) {
+          setRequiresSession(true);
+          notification.error(SESSION_MESSAGES.withdrawSyncAfterOnChainFailed);
+          return;
+        }
+
         const errorMessage = getParsedError(error);
         notification.error(errorMessage);
+      }
+    };
+
+    const handleReauthenticateAndRetry = async () => {
+      if (isReauthenticating) return;
+
+      setIsReauthenticating(true);
+      try {
+        const loggedIn = await handleLogin();
+        if (!loggedIn) {
+          notification.error(SESSION_MESSAGES.reauthFailed);
+          return;
+        }
+
+        const hasUserSession = await hasActiveUserSession();
+        if (!hasUserSession) {
+          setRequiresSession(true);
+          notification.error(SESSION_MESSAGES.sessionStillUnavailable);
+          return;
+        }
+
+        setRequiresSession(false);
+
+        const completionProof = pendingCompletionProof || getValues("completionProof");
+        if (!pendingPaymentTx || !completionProof) {
+          notification.success(SESSION_MESSAGES.sessionRestoredWithdrawAgain);
+          return;
+        }
+
+        await postCompleteMilestone({
+          paymentTx: pendingPaymentTx,
+          completionProof,
+        });
+
+        setPendingPaymentTx(null);
+        setPendingCompletionProof(null);
+
+        await apolloClient.refetchQueries({
+          include: "active",
+        });
+        await refetchContractInfo();
+
+        closeModal();
+        clearFormValues();
+        router.refresh();
+      } catch (error) {
+        if ((error as { status?: number })?.status === 401) {
+          setRequiresSession(true);
+          notification.error(SESSION_MESSAGES.withdrawSyncAfterOnChainFailed);
+          return;
+        }
+
+        const errorMessage = getParsedError(error);
+        notification.error(errorMessage);
+      } finally {
+        setIsReauthenticating(false);
       }
     };
 
@@ -122,9 +218,31 @@ export const WithdrawModal = forwardRef<HTMLDialogElement, WithdrawModalProps>(
                   *Video walkthrough, GitHub repo or other deliverables
                 </span>
               </div>
+              {(pendingPaymentTx || requiresSession) && (
+                <div className="rounded-lg border border-warning px-3 py-2 my-2">
+                  <p className="text-sm mb-2">
+                    {pendingPaymentTx ? REAUTH_UI_TEXT.withdrawPendingSync : REAUTH_UI_TEXT.withdrawSessionExpired}
+                  </p>
+                  <Button
+                    variant="secondary"
+                    type="button"
+                    className="self-start"
+                    onClick={handleReauthenticateAndRetry}
+                    disabled={isReauthenticating || isPostingCompleteMilestone}
+                  >
+                    {isReauthenticating
+                      ? REAUTH_UI_TEXT.reauthenticating
+                      : pendingPaymentTx
+                      ? REAUTH_UI_TEXT.reauthAndRetry
+                      : REAUTH_UI_TEXT.reauth}
+                  </Button>
+                </div>
+              )}
               <Button
                 type="submit"
-                disabled={isWritingWithOnChain || isPostingCompleteMilestone || isLoadingMilestoneStatus}
+                disabled={
+                  isWritingWithOnChain || isPostingCompleteMilestone || isLoadingMilestoneStatus || isReauthenticating
+                }
                 className="self-center"
               >
                 {(isWritingWithOnChain || isPostingCompleteMilestone || isLoadingMilestoneStatus) && (

--- a/packages/nextjs/app/large-grants/[grantId]/_components/CurrentStage/CompleteMilestoneModal/index.tsx
+++ b/packages/nextjs/app/large-grants/[grantId]/_components/CurrentStage/CompleteMilestoneModal/index.tsx
@@ -26,15 +26,12 @@ export const CompleteMilestoneModal = forwardRef<HTMLDialogElement, WithdrawModa
     const { handleSubmit, reset: clearFormValues } = formMethods;
 
     const onSubmit = async (fieldValues: CompleteMilestoneModalFormValues) => {
-      try {
-        const { completionProof } = fieldValues;
-        await reviewMilestone({ status: "completed", completionProof });
-        closeModal();
-        clearFormValues();
-        router.refresh();
-      } catch (error) {
-        console.error("Error completing milestone:", error);
-      }
+      const { completionProof } = fieldValues;
+      const isReviewed = await reviewMilestone({ status: "completed", completionProof });
+      if (!isReviewed) return;
+      closeModal();
+      clearFormValues();
+      router.refresh();
     };
 
     return (

--- a/packages/nextjs/hooks/pg-ens/useHandleLogin.ts
+++ b/packages/nextjs/hooks/pg-ens/useHandleLogin.ts
@@ -9,6 +9,8 @@ export const useHandleLogin = () => {
 
   const handleLogin = useCallback(async () => {
     try {
+      if (!address) return false;
+
       const message = new SiweMessage({
         domain: window.location.host,
         address: address,
@@ -21,12 +23,16 @@ export const useHandleLogin = () => {
       const signature = await signMessageAsync({
         message: message.prepareMessage(),
       });
-      signIn("credentials", {
+      const result = await signIn("credentials", {
         message: JSON.stringify(message),
         signature,
+        redirect: false,
       });
+
+      return Boolean(result?.ok);
     } catch (error) {
       console.log(error);
+      return false;
     }
   }, [address, chain?.id, signMessageAsync]);
 

--- a/packages/nextjs/hooks/pg-ens/useLargeMilestoneReview.ts
+++ b/packages/nextjs/hooks/pg-ens/useLargeMilestoneReview.ts
@@ -3,9 +3,11 @@ import { useMutation } from "@tanstack/react-query";
 import { useAccount, useSignTypedData } from "wagmi";
 import { ReviewMilestoneBody } from "~~/app/api/large-milestones/[milestoneId]/review/route";
 import { MilestoneStatus } from "~~/services/database/config/schema";
+import { hasActiveAdminSession, hasActiveUserSession } from "~~/utils/admin-session";
 import { EIP_712_DOMAIN, EIP_712_TYPES__REVIEW_LARGE_MILESTONE } from "~~/utils/eip712";
 import { postMutationFetcher } from "~~/utils/react-query";
 import { getParsedError, notification } from "~~/utils/scaffold-eth";
+import { SESSION_MESSAGES } from "~~/utils/session-messages";
 
 export const useLargeMilestoneReview = (milestoneId?: number) => {
   const router = useRouter();
@@ -28,17 +30,27 @@ export const useLargeMilestoneReview = (milestoneId?: number) => {
     statusNote?: string;
     completionProof?: string;
   }) => {
-    if (!milestoneId) return;
+    if (!milestoneId) return false;
     let notificationId;
     try {
       if (!connectedAddress) {
         notification.error("Please connect your wallet");
-        return;
+        return false;
       }
 
       if ((status === "verified" || status === "paid") && !txHash) {
         notification.error("Please fill tx hash");
-        return;
+        return false;
+      }
+
+      if (!(await hasActiveUserSession())) {
+        notification.error(SESSION_MESSAGES.genericExpiredRetry);
+        return false;
+      }
+
+      if (status !== "completed" && !(await hasActiveAdminSession())) {
+        notification.error(SESSION_MESSAGES.adminExpiredMilestoneApproval);
+        return false;
       }
 
       const signature = await signTypedDataAsync({
@@ -79,10 +91,16 @@ export const useLargeMilestoneReview = (milestoneId?: number) => {
       notification.remove(notificationId);
       notification.success(`Milestone ${status}`);
       router.refresh();
+      return true;
     } catch (error) {
       if (notificationId) notification.remove(notificationId);
+      if ((error as { status?: number })?.status === 401) {
+        notification.error(SESSION_MESSAGES.genericExpiredRetry);
+        return false;
+      }
       const errorMessage = getParsedError(error);
       notification.error(errorMessage);
+      return false;
     }
   };
 

--- a/packages/nextjs/hooks/pg-ens/useLargeStageReview.ts
+++ b/packages/nextjs/hooks/pg-ens/useLargeStageReview.ts
@@ -3,9 +3,11 @@ import { useMutation } from "@tanstack/react-query";
 import { useAccount, useSignTypedData } from "wagmi";
 import { ReviewStageBody } from "~~/app/api/stages/[stageId]/review/route";
 import { Status } from "~~/services/database/repositories/stages";
+import { hasActiveAdminSession, hasActiveUserSession } from "~~/utils/admin-session";
 import { EIP_712_DOMAIN, EIP_712_TYPES__REVIEW_LARGE_STAGE } from "~~/utils/eip712";
 import { postMutationFetcher } from "~~/utils/react-query";
 import { getParsedError, notification } from "~~/utils/scaffold-eth";
+import { SESSION_MESSAGES } from "~~/utils/session-messages";
 
 export const useLargeStageReview = (stageId?: number) => {
   const router = useRouter();
@@ -26,17 +28,27 @@ export const useLargeStageReview = (stageId?: number) => {
     txHash?: string;
     statusNote?: string;
   }) => {
-    if (!stageId) return;
+    if (!stageId) return false;
     let notificationId;
     try {
       if (!connectedAddress) {
         notification.error("Please connect your wallet");
-        return;
+        return false;
       }
 
       if (status === "approved" && !txHash) {
         notification.error("Please fill tx hash");
-        return;
+        return false;
+      }
+
+      if (!(await hasActiveUserSession())) {
+        notification.error(SESSION_MESSAGES.genericExpiredRetry);
+        return false;
+      }
+
+      if (status !== "completed" && !(await hasActiveAdminSession())) {
+        notification.error(SESSION_MESSAGES.adminExpiredFinalApproval);
+        return false;
       }
 
       const signature = await signTypedDataAsync({
@@ -61,10 +73,16 @@ export const useLargeStageReview = (stageId?: number) => {
       notification.remove(notificationId);
       notification.success(`Grant ${status}`);
       router.refresh();
+      return true;
     } catch (error) {
       if (notificationId) notification.remove(notificationId);
+      if ((error as { status?: number })?.status === 401) {
+        notification.error(SESSION_MESSAGES.genericExpiredRetry);
+        return false;
+      }
       const errorMessage = getParsedError(error);
       notification.error(errorMessage);
+      return false;
     }
   };
 

--- a/packages/nextjs/hooks/pg-ens/useStageReview.ts
+++ b/packages/nextjs/hooks/pg-ens/useStageReview.ts
@@ -3,9 +3,11 @@ import { useMutation } from "@tanstack/react-query";
 import { useAccount, useSignTypedData } from "wagmi";
 import { ReviewStageBody } from "~~/app/api/stages/[stageId]/review/route";
 import { Status } from "~~/services/database/repositories/stages";
+import { hasActiveAdminSession, hasActiveUserSession } from "~~/utils/admin-session";
 import { EIP_712_DOMAIN, EIP_712_TYPES__REVIEW_STAGE } from "~~/utils/eip712";
 import { postMutationFetcher } from "~~/utils/react-query";
 import { getParsedError, notification } from "~~/utils/scaffold-eth";
+import { SESSION_MESSAGES } from "~~/utils/session-messages";
 
 export const useStageReview = (stageId?: number) => {
   const router = useRouter();
@@ -32,17 +34,27 @@ export const useStageReview = (stageId?: number) => {
     grantNumber?: string;
     milestones?: { grantedAmount: string }[];
   }) => {
-    if (!stageId) return;
+    if (!stageId) return false;
     let notificationId;
     try {
       if (!connectedAddress) {
         notification.error("Please connect your wallet");
-        return;
+        return false;
       }
 
       if (status === "approved" && !txHash) {
         notification.error("Please fill tx hash");
-        return;
+        return false;
+      }
+
+      if (!(await hasActiveUserSession())) {
+        notification.error(SESSION_MESSAGES.genericExpiredRetry);
+        return false;
+      }
+
+      if (status !== "completed" && !(await hasActiveAdminSession())) {
+        notification.error(SESSION_MESSAGES.adminExpiredFinalApproval);
+        return false;
       }
 
       const signature = await signTypedDataAsync({
@@ -72,10 +84,16 @@ export const useStageReview = (stageId?: number) => {
       notification.remove(notificationId);
       notification.success(`Grant ${status}`);
       router.refresh();
+      return true;
     } catch (error) {
       if (notificationId) notification.remove(notificationId);
+      if ((error as { status?: number })?.status === 401) {
+        notification.error(SESSION_MESSAGES.genericExpiredRetry);
+        return false;
+      }
       const errorMessage = getParsedError(error);
       notification.error(errorMessage);
+      return false;
     }
   };
 

--- a/packages/nextjs/utils/admin-session.ts
+++ b/packages/nextjs/utils/admin-session.ts
@@ -1,0 +1,11 @@
+import { getSession } from "next-auth/react";
+
+export const hasActiveUserSession = async () => {
+  const session = await getSession();
+  return Boolean(session?.user?.address);
+};
+
+export const hasActiveAdminSession = async () => {
+  const session = await getSession();
+  return Boolean(session?.user?.address) && session?.user?.role === "admin";
+};

--- a/packages/nextjs/utils/react-query.ts
+++ b/packages/nextjs/utils/react-query.ts
@@ -18,7 +18,9 @@ export const makeMutationFetcher =
     const data = await res.json();
 
     if (!res.ok) {
-      throw new Error(data.error || `Error ${method.toLowerCase()}ing data`);
+      const error = new Error(data.error || `Error ${method.toLowerCase()}ing data`) as Error & { status?: number };
+      error.status = res.status;
+      throw error;
     }
     return data;
   };

--- a/packages/nextjs/utils/session-messages.ts
+++ b/packages/nextjs/utils/session-messages.ts
@@ -1,0 +1,27 @@
+export const SESSION_MESSAGES = {
+  genericExpiredRetry: "Session expired. Please sign in again and retry.",
+  adminExpiredFinalApproval: "Admin session expired. Please sign in again before final approval.",
+  adminExpiredMilestoneApproval: "Admin session expired. Please sign in again before milestone approval.",
+  adminPermissionsRequired: "Re-authenticated, but admin permissions are required.",
+  reauthFailed: "Could not re-authenticate. Please try again.",
+  sessionRestoredSubmitAgain: "Session restored. You can submit final approval now.",
+  sessionRestoredWithdrawAgain: "Session restored. You can withdraw now.",
+  reviewSyncAfterOnChainFailed:
+    "On-chain transaction succeeded, but stage review failed. Sign in again and retry to sync status.",
+  milestoneSyncAfterOnChainFailed:
+    "On-chain transaction succeeded, but milestone review failed. Sign in again and retry to sync status.",
+  withdrawSyncAfterOnChainFailed: "On-chain withdraw succeeded, but your session expired. Re-authenticate and retry.",
+  sessionStillUnavailable: "Session is still unavailable. Please try again.",
+} as const;
+
+export const REAUTH_UI_TEXT = {
+  reauth: "Re-authenticate",
+  reauthAndRetry: "Re-authenticate & Retry",
+  reauthenticating: "Re-authenticating...",
+  finalApprovalPendingSync: "On-chain transaction is already confirmed. Re-authenticate to sync approval status.",
+  finalApprovalSessionExpired: "Admin session expired. Re-authenticate to continue final approval.",
+  milestonePendingSync: "On-chain transaction is already confirmed. Re-authenticate to sync milestone status.",
+  milestoneSessionExpired: "Admin session expired. Re-authenticate to continue milestone approval.",
+  withdrawPendingSync: "On-chain withdraw is confirmed. Re-authenticate to sync milestone payment status.",
+  withdrawSessionExpired: "Session expired. Re-authenticate to continue withdraw.",
+} as const;


### PR DESCRIPTION
Summary
  
  - Add pre-flight session validation before on-chain transactions to prevent partial failures where the blockchain tx succeeds but the DB sync fails due to an expired session
  - Introduce a re-authenticate & retry flow in modals so users don't need to redo an already-confirmed on-chain transaction when their session expires mid-flow
  - Centralize session error messages and UI text into dedicated constants files

  Details

  New utilities:
  - utils/admin-session.ts — hasActiveUserSession() and hasActiveAdminSession() helpers that check the NextAuth session before proceeding
  - utils/session-messages.ts — SESSION_MESSAGES and REAUTH_UI_TEXT constants for consistent session-related error/UI copy

  Review hooks (useStageReview, useLargeStageReview, useLargeMilestoneReview):
  - Now check for an active user/admin session before signing typed data
  - Return boolean (success/failure) instead of void so callers can branch on the result
  - Surface 401 HTTP errors with a specific "session expired" notification

  Admin modals (FinalApproveModal, LargeGrantFinalApproveModal, LargeMilestoneApprovalModal):
  - Check admin session before initiating the on-chain transaction
  - If the on-chain tx succeeds but the session expires before the DB sync, the tx hash is stored in local state
  - A "Re-authenticate & Retry" button appears, allowing the admin to sign back in and complete the DB sync without repeating the on-chain transaction

  WithdrawModal (grantee-facing):
  - Same re-authenticate & retry pattern for user sessions — stores the pending tx hash and completion proof if the DB sync fails after the on-chain withdrawal confirms
  
  CompleteMilestoneModal (large grants, grantee-facing):
  - Simplified: now uses the boolean return from reviewMilestone to gate the close/reset flow instead of wrapping in a try/catch
  
  useHandleLogin: now returns true/false so callers can act on login success/failure.

  utils/react-query.ts: attaches the HTTP status code to thrown errors so hooks can distinguish 401 session errors from other failures.

  Test plan

  - [ ] Trigger an admin action with an expired session — confirm an error notification appears and the on-chain tx is blocked
  - [ ] Let an admin session expire after an on-chain tx confirms but before the DB sync — confirm "Re-authenticate & Retry" completes the sync without a second on-chain tx
  - [ ] Re-authenticate as a non-admin — confirm the "admin permissions required" message appears
  - [ ] Trigger a withdrawal with an expired user session — confirm the re-auth & retry flow works
  - [ ] Complete a large-grant milestone — confirm the modal closes only on success
  - [ ] Happy path: full final approval, milestone approval, and withdrawal flows work end-to-end with a valid session